### PR TITLE
feat(deploy): add WSL2 office bootstrap workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,8 @@ coverage/
 # Agent
 .agent/
 .agents/
+.runtime/
+.worktrees/
 .claude/settings.local.json
 .codex/skills/openclaw-office-release/
 

--- a/scripts/start-openclaw-office.ps1
+++ b/scripts/start-openclaw-office.ps1
@@ -1,0 +1,280 @@
+[CmdletBinding()]
+param(
+  [string]$Distro = "",
+  [string]$OpenClawVersion = "2026.3.28",
+  [int]$OfficePort = 5180,
+  [int]$GatewayPort = 18789
+)
+
+$ErrorActionPreference = "Stop"
+
+function Convert-ToWslPath {
+  param([Parameter(Mandatory = $true)][string]$WindowsPath)
+
+  $normalized = $WindowsPath -replace "\\", "/"
+  if ($normalized -match "^([A-Za-z]):/(.*)$") {
+    $drive = $Matches[1].ToLowerInvariant()
+    $rest = $Matches[2]
+    return "/mnt/$drive/$rest"
+  }
+
+  throw "无法转换为 WSL 路径: $WindowsPath"
+}
+
+function Convert-ToBashLiteral {
+  param([Parameter(Mandatory = $true)][string]$Value)
+
+  return "'" + ($Value -replace "'", "'""'""'") + "'"
+}
+
+function Get-PreferredDistro {
+  $lines = & wsl.exe --list --quiet 2>$null
+  if (-not $lines) {
+    throw "未检测到可用的 WSL 发行版。"
+  }
+
+  $candidates = @()
+  foreach ($line in $lines) {
+    $trimmed = $line.Trim()
+    if (-not $trimmed) {
+      continue
+    }
+    if ($trimmed -like "docker-desktop*") {
+      continue
+    }
+    $candidates += $trimmed
+  }
+
+  if ($candidates.Count -eq 0) {
+    throw "未找到可用于 OpenClaw 的 WSL Linux 发行版。"
+  }
+
+  return $candidates[0]
+}
+
+function Wait-ForHttp {
+  param(
+    [Parameter(Mandatory = $true)][string]$Url,
+    [int]$Retries = 60,
+    [int]$DelaySeconds = 2
+  )
+
+  for ($i = 0; $i -lt $Retries; $i++) {
+    try {
+      Invoke-WebRequest -Uri $Url -UseBasicParsing -TimeoutSec 3 | Out-Null
+      return $true
+    } catch {
+      Start-Sleep -Seconds $DelaySeconds
+    }
+  }
+
+  return $false
+}
+
+function Get-WslCommandOutput {
+  param(
+    [Parameter(Mandatory = $true)][string]$DistroName,
+    [Parameter(Mandatory = $true)][string]$Command,
+    [string]$User = ""
+  )
+
+  $arguments = @("-d", $DistroName)
+  if (-not [string]::IsNullOrWhiteSpace($User)) {
+    $arguments += @("-u", $User)
+  }
+  $arguments += @("--", "bash", "-lc", $Command)
+
+  $output = & wsl.exe @arguments 2>$null
+  return (($output | ForEach-Object { $_.ToString().Trim() }) -join "`n").Trim()
+}
+
+function Test-VersionAtLeast {
+  param(
+    [Parameter(Mandatory = $true)][string]$Current,
+    [Parameter(Mandatory = $true)][string]$Minimum
+  )
+
+  try {
+    $currentVersion = [version]$Current
+    $minimumVersion = [version]$Minimum
+    return $currentVersion -ge $minimumVersion
+  } catch {
+    return $false
+  }
+}
+
+function Ensure-WslBaseRuntime {
+  param(
+    [Parameter(Mandatory = $true)][string]$DistroName,
+    [Parameter(Mandatory = $true)][string]$DesiredOpenClawVersion
+  )
+
+  $nodeVersionRaw = Get-WslCommandOutput -DistroName $DistroName -Command "node -v 2>/dev/null | sed 's/^v//'"
+  $openclawVersion = Get-WslCommandOutput -DistroName $DistroName -Command "openclaw --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -n 1"
+
+  $needsNode = -not (Test-VersionAtLeast -Current $nodeVersionRaw -Minimum "22.14")
+  $needsOpenClaw = $openclawVersion -ne $DesiredOpenClawVersion
+
+  if (-not $needsNode -and -not $needsOpenClaw) {
+    return
+  }
+
+  Write-Host "检测到 WSL 运行时需要补齐，正在以 root 安装 Node.js 与 OpenClaw..."
+  $rootCommand = @(
+    "set -euo pipefail"
+    "export DEBIAN_FRONTEND=noninteractive"
+    "apt-get update"
+    "apt-get install -y ca-certificates curl gnupg"
+    "curl -fsSL https://deb.nodesource.com/setup_22.x | bash -"
+    "apt-get install -y nodejs"
+    "env SHARP_IGNORE_GLOBAL_LIBVIPS=1 npm install -g openclaw@$DesiredOpenClawVersion"
+  ) -join "; "
+
+  & wsl.exe -d $DistroName -u root -- bash -lc $rootCommand
+  if ($LASTEXITCODE -ne 0) {
+    throw "WSL root 运行时安装失败，退出码：$LASTEXITCODE"
+  }
+}
+
+function Get-WslGatewayToken {
+  param([Parameter(Mandatory = $true)][string]$DistroName)
+
+  $rawConfig = & wsl.exe -d $DistroName -- bash -lc "cat ~/.openclaw/openclaw.json" 2>$null
+  if ($LASTEXITCODE -ne 0 -or -not $rawConfig) {
+    throw "未能读取 WSL OpenClaw 配置文件。"
+  }
+
+  $config = ($rawConfig -join "`n") | ConvertFrom-Json
+  $token = $config.gateway.auth.token
+  if ([string]::IsNullOrWhiteSpace($token)) {
+    throw "未能从 WSL OpenClaw 配置读取 Gateway Token。"
+  }
+  return $token.Trim()
+}
+
+function Stop-ExistingWindowsOffice {
+  param([Parameter(Mandatory = $true)][string]$PidFile)
+
+  if (-not (Test-Path $PidFile)) {
+    return
+  }
+
+  $rawPid = (Get-Content -Path $PidFile -ErrorAction SilentlyContinue | Select-Object -First 1)
+  if (-not $rawPid) {
+    Remove-Item -Path $PidFile -Force -ErrorAction SilentlyContinue
+    return
+  }
+
+  $existingProcess = Get-Process -Id ([int]$rawPid) -ErrorAction SilentlyContinue
+  if ($existingProcess) {
+    Stop-Process -Id $existingProcess.Id -Force -ErrorAction SilentlyContinue
+    Start-Sleep -Seconds 1
+  }
+
+  Remove-Item -Path $PidFile -Force -ErrorAction SilentlyContinue
+}
+
+function Start-WindowsOffice {
+  param(
+    [Parameter(Mandatory = $true)][string]$RepoRoot,
+    [Parameter(Mandatory = $true)][string]$GatewayToken,
+    [Parameter(Mandatory = $true)][int]$OfficeListenPort,
+    [Parameter(Mandatory = $true)][int]$GatewayListenPort,
+    [Parameter(Mandatory = $true)][string]$PidFile,
+    [Parameter(Mandatory = $true)][string]$LogFile
+  )
+
+  if (-not (Get-Command node -ErrorAction SilentlyContinue)) {
+    throw "当前 Windows 环境缺少 node，无法启动 OpenClaw Office。"
+  }
+
+  Stop-ExistingWindowsOffice -PidFile $PidFile
+
+  $officeEntry = Join-Path $RepoRoot "bin\openclaw-office.js"
+  $errorLogFile = [System.IO.Path]::ChangeExtension($LogFile, ".err.log")
+  if (-not (Test-Path $officeEntry)) {
+    throw "未找到 Office 启动入口: $officeEntry"
+  }
+
+  $process = Start-Process `
+    -FilePath "node" `
+    -ArgumentList @(
+      $officeEntry,
+      "--host", "127.0.0.1",
+      "--port", "$OfficeListenPort",
+      "--gateway", "ws://127.0.0.1:$GatewayListenPort",
+      "--token", $GatewayToken
+    ) `
+    -WorkingDirectory $RepoRoot `
+    -RedirectStandardOutput $LogFile `
+    -RedirectStandardError $errorLogFile `
+    -PassThru
+
+  Set-Content -Path $PidFile -Value $process.Id -NoNewline
+}
+
+if (-not (Get-Command wsl.exe -ErrorAction SilentlyContinue)) {
+  throw "当前系统未安装 WSL。请先以管理员身份执行 wsl --install。"
+}
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+$bootstrapWindowsPath = Join-Path $repoRoot "scripts\wsl-bootstrap-openclaw-office.sh"
+$runtimeDir = Join-Path $repoRoot ".runtime"
+$officePidFile = Join-Path $runtimeDir "openclaw-office-windows.pid"
+$officeLogFile = Join-Path $runtimeDir "openclaw-office-windows.log"
+
+if (-not (Test-Path $bootstrapWindowsPath)) {
+  throw "未找到 WSL 部署脚本: $bootstrapWindowsPath"
+}
+
+if (-not (Test-Path $runtimeDir)) {
+  New-Item -Path $runtimeDir -ItemType Directory | Out-Null
+}
+
+$resolvedDistro = if ([string]::IsNullOrWhiteSpace($Distro)) { Get-PreferredDistro } else { $Distro }
+$wslRepoRoot = Convert-ToWslPath -WindowsPath $repoRoot
+$wslBootstrapPath = Convert-ToWslPath -WindowsPath $bootstrapWindowsPath
+$officeUrl = "http://127.0.0.1:$OfficePort"
+
+Write-Host ""
+Write-Host "OpenClaw Office WSL2 部署启动中..."
+Write-Host "WSL 发行版: $resolvedDistro"
+Write-Host "项目目录: $repoRoot"
+Write-Host ""
+
+Ensure-WslBaseRuntime -DistroName $resolvedDistro -DesiredOpenClawVersion $OpenClawVersion
+
+$bashCommand = @(
+  "export OPENCLAW_VERSION=$(Convert-ToBashLiteral -Value $OpenClawVersion)"
+  "export OPENCLAW_OFFICE_PORT=$(Convert-ToBashLiteral -Value $OfficePort)"
+  "export OPENCLAW_GATEWAY_PORT=$(Convert-ToBashLiteral -Value $GatewayPort)"
+  "export OPENCLAW_SKIP_OFFICE_START='1'"
+  "bash $(Convert-ToBashLiteral -Value $wslBootstrapPath) $(Convert-ToBashLiteral -Value $wslRepoRoot)"
+) -join "; "
+
+& wsl.exe -d $resolvedDistro --cd $wslRepoRoot bash -lc $bashCommand
+
+if ($LASTEXITCODE -ne 0) {
+  throw "WSL 部署脚本执行失败，退出码：$LASTEXITCODE"
+}
+
+$gatewayToken = Get-WslGatewayToken -DistroName $resolvedDistro
+Start-WindowsOffice `
+  -RepoRoot $repoRoot `
+  -GatewayToken $gatewayToken `
+  -OfficeListenPort $OfficePort `
+  -GatewayListenPort $GatewayPort `
+  -PidFile $officePidFile `
+  -LogFile $officeLogFile
+
+Write-Host ""
+Write-Host "等待 OpenClaw Office 就绪..."
+
+if (-not (Wait-ForHttp -Url $officeUrl)) {
+  throw "OpenClaw Office 未在预期时间内启动：$officeUrl"
+}
+
+Start-Process $officeUrl | Out-Null
+
+Write-Host ""
+Write-Host "OpenClaw Office 已启动：$officeUrl"

--- a/scripts/wsl-bootstrap-openclaw-office.sh
+++ b/scripts/wsl-bootstrap-openclaw-office.sh
@@ -1,0 +1,320 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROJECT_DIR="${1:-}"
+OPENCLAW_VERSION="${OPENCLAW_VERSION:-2026.3.28}"
+OPENCLAW_GATEWAY_PORT="${OPENCLAW_GATEWAY_PORT:-18789}"
+OPENCLAW_OFFICE_PORT="${OPENCLAW_OFFICE_PORT:-5180}"
+OPENCLAW_SKIP_OFFICE_START="${OPENCLAW_SKIP_OFFICE_START:-0}"
+RUNTIME_DIR=""
+GATEWAY_LOG=""
+GATEWAY_PID_FILE=""
+OFFICE_LOG=""
+OFFICE_PID_FILE=""
+
+if [[ -z "$PROJECT_DIR" ]]; then
+  echo "缺少项目目录参数。"
+  exit 1
+fi
+
+RUNTIME_DIR="$PROJECT_DIR/.runtime"
+GATEWAY_LOG="$RUNTIME_DIR/openclaw-gateway.log"
+GATEWAY_PID_FILE="$RUNTIME_DIR/openclaw-gateway.pid"
+OFFICE_LOG="$RUNTIME_DIR/openclaw-office.log"
+OFFICE_PID_FILE="$RUNTIME_DIR/openclaw-office.pid"
+
+mkdir -p "$RUNTIME_DIR"
+
+step() {
+  printf "\n[%s] %s\n" "$1" "$2"
+}
+
+can_sudo_without_prompt() {
+  command -v sudo >/dev/null 2>&1 && sudo -n true >/dev/null 2>&1
+}
+
+wait_for_http() {
+  local url="$1"
+  local retries="$2"
+  local delay="$3"
+  local i
+  for ((i = 0; i < retries; i++)); do
+    if curl -fsS "$url" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep "$delay"
+  done
+  return 1
+}
+
+ensure_systemd() {
+  if [[ "$(ps -p 1 -o comm= 2>/dev/null || true)" == "systemd" ]]; then
+    return 0
+  fi
+
+  step "wsl" "检测到当前 WSL 未启用 systemd，尝试自动修复"
+  if ! command -v sudo >/dev/null 2>&1; then
+    echo "当前 WSL 环境缺少 sudo，无法自动启用 systemd。"
+    echo "请先在 WSL 中安装 sudo 并重新运行。"
+    exit 1
+  fi
+
+  printf "[boot]\nsystemd=true\n" | sudo tee /etc/wsl.conf >/dev/null
+  echo "已写入 /etc/wsl.conf。请在 Windows 中执行 wsl --shutdown 后重新双击启动。"
+  exit 1
+}
+
+ensure_node() {
+  local current_version=""
+  local major=0
+  local minor=0
+
+  if command -v node >/dev/null 2>&1; then
+    current_version="$(node -v 2>/dev/null | sed 's/^v//' || true)"
+    major="${current_version%%.*}"
+    local rest="${current_version#*.}"
+    minor="${rest%%.*}"
+
+    if [[ "$major" =~ ^[0-9]+$ ]] && [[ "$minor" =~ ^[0-9]+$ ]]; then
+      if (( major > 22 )) || (( major == 22 && minor >= 14 )); then
+        return 0
+      fi
+    fi
+  fi
+
+  if ! can_sudo_without_prompt; then
+    echo "当前 WSL 用户无法无密码提权安装 Node.js。"
+    echo "请通过 Windows 启动器运行，或先在 WSL 中配置 sudo -n 可用后重试。"
+    exit 1
+  fi
+
+  step "node" "升级 Node.js 到 22.14+"
+  sudo -n apt-get update
+  sudo -n apt-get install -y ca-certificates curl gnupg
+  curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -n -E bash -
+  sudo -n apt-get install -y nodejs
+
+  current_version="$(node -v 2>/dev/null | sed 's/^v//' || true)"
+  major="${current_version%%.*}"
+  local upgraded_rest="${current_version#*.}"
+  minor="${upgraded_rest%%.*}"
+  if ! [[ "$major" =~ ^[0-9]+$ ]] || ! [[ "$minor" =~ ^[0-9]+$ ]] || (( major < 22 )) || (( major == 22 && minor < 14 )); then
+    echo "Node.js 升级失败，当前版本为：${current_version:-unknown}"
+    exit 1
+  fi
+}
+
+ensure_pnpm() {
+  if command -v pnpm >/dev/null 2>&1; then
+    return 0
+  fi
+
+  step "pnpm" "启用 Corepack 并安装 pnpm"
+  corepack enable
+  corepack prepare pnpm@10.26.1 --activate
+}
+
+install_openclaw() {
+  local current_version=""
+
+  if command -v openclaw >/dev/null 2>&1; then
+    current_version="$(openclaw --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -n 1 || true)"
+  fi
+
+  if [[ "$current_version" == "$OPENCLAW_VERSION" ]]; then
+    return 0
+  fi
+
+  step "openclaw" "安装 OpenClaw ${OPENCLAW_VERSION}"
+  if ! npm install -g "openclaw@${OPENCLAW_VERSION}"; then
+    if ! can_sudo_without_prompt; then
+      echo "当前 WSL 用户无权全局安装 OpenClaw。"
+      echo "请通过 Windows 启动器运行，或先在 WSL 中配置 sudo -n 可用后重试。"
+      exit 1
+    fi
+    sudo -n env SHARP_IGNORE_GLOBAL_LIBVIPS=1 npm install -g "openclaw@${OPENCLAW_VERSION}"
+  fi
+
+  current_version="$(openclaw --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -n 1 || true)"
+  if [[ "$current_version" != "$OPENCLAW_VERSION" ]]; then
+    echo "OpenClaw 安装失败，当前版本为：${current_version:-unknown}"
+    exit 1
+  fi
+}
+
+ensure_openclaw_config() {
+  local config_path="${OPENCLAW_CONFIG_PATH:-$HOME/.openclaw/openclaw.json}"
+  local generated_token=""
+
+  if [[ -f "$config_path" ]]; then
+    return 0
+  fi
+
+  step "openclaw" "自动初始化 OpenClaw 配置"
+  generated_token="$(node -e "console.log(require('node:crypto').randomUUID().replace(/-/g, ''))")"
+  openclaw onboard \
+    --non-interactive \
+    --accept-risk \
+    --flow manual \
+    --mode local \
+    --auth-choice skip \
+    --gateway-auth token \
+    --gateway-token "$generated_token" \
+    --skip-channels \
+    --skip-search \
+    --skip-skills \
+    --skip-ui \
+    --skip-health \
+    --no-install-daemon \
+    --json >/dev/null
+
+  if [[ ! -f "$config_path" ]]; then
+    echo "OpenClaw 初始化失败，未生成配置文件。"
+    exit 1
+  fi
+}
+
+configure_gateway() {
+  step "gateway" "写入 Control UI 所需配置"
+  openclaw config set gateway.controlUi.dangerouslyDisableDeviceAuth true
+  openclaw config set gateway.controlUi.allowInsecureAuth true
+}
+
+start_gateway_service() {
+  local status_output=""
+
+  step "gateway" "安装并启动 Gateway 服务"
+  openclaw gateway install || true
+  openclaw gateway restart || true
+  status_output="$(openclaw gateway status 2>&1 || true)"
+
+  if printf "%s" "$status_output" | grep -qi "Runtime:[[:space:]]*running"; then
+    return 0
+  fi
+
+  if [[ -f "$GATEWAY_PID_FILE" ]]; then
+    local old_pid
+    old_pid="$(cat "$GATEWAY_PID_FILE" 2>/dev/null || true)"
+    if [[ -n "$old_pid" ]] && kill -0 "$old_pid" 2>/dev/null; then
+      kill "$old_pid" 2>/dev/null || true
+      sleep 1
+    fi
+  fi
+
+  nohup openclaw gateway --port "$OPENCLAW_GATEWAY_PORT" >"$GATEWAY_LOG" 2>&1 &
+  echo "$!" >"$GATEWAY_PID_FILE"
+}
+
+wait_for_gateway() {
+  local retries=60
+  local i
+  for ((i = 0; i < retries; i++)); do
+    if openclaw gateway status 2>&1 | grep -qi "Runtime:[[:space:]]*running"; then
+      return 0
+    fi
+    sleep 2
+  done
+
+  echo "Gateway 启动失败，请检查日志：$GATEWAY_LOG"
+  openclaw gateway status || true
+  exit 1
+}
+
+install_office_dependencies() {
+  step "office" "安装前端依赖"
+  cd "$PROJECT_DIR"
+  CI=1 pnpm install --force
+}
+
+needs_build() {
+  if [[ ! -f "$PROJECT_DIR/dist/index.html" ]]; then
+    return 0
+  fi
+
+  if [[ "$PROJECT_DIR/package.json" -nt "$PROJECT_DIR/dist/index.html" ]]; then
+    return 0
+  fi
+
+  if [[ "$PROJECT_DIR/pnpm-lock.yaml" -nt "$PROJECT_DIR/dist/index.html" ]]; then
+    return 0
+  fi
+
+  if find "$PROJECT_DIR/src" "$PROJECT_DIR/public" -type f -newer "$PROJECT_DIR/dist/index.html" | grep -q .; then
+    return 0
+  fi
+
+  return 1
+}
+
+build_office_if_needed() {
+  if ! needs_build; then
+    return 0
+  fi
+
+  step "office" "构建 OpenClaw Office 生产版本"
+  cd "$PROJECT_DIR"
+  pnpm build
+}
+
+stop_existing_office() {
+  if [[ ! -f "$OFFICE_PID_FILE" ]]; then
+    return 0
+  fi
+
+  local old_pid
+  old_pid="$(cat "$OFFICE_PID_FILE" 2>/dev/null || true)"
+  if [[ -n "$old_pid" ]] && kill -0 "$old_pid" 2>/dev/null; then
+    kill "$old_pid" 2>/dev/null || true
+    sleep 1
+  fi
+}
+
+start_office() {
+  step "office" "启动 OpenClaw Office"
+  stop_existing_office
+  cd "$PROJECT_DIR"
+  nohup node ./bin/openclaw-office.js \
+    --host 0.0.0.0 \
+    --port "$OPENCLAW_OFFICE_PORT" \
+    --gateway "ws://127.0.0.1:${OPENCLAW_GATEWAY_PORT}" \
+    >"$OFFICE_LOG" 2>&1 &
+  echo "$!" >"$OFFICE_PID_FILE"
+}
+
+print_gateway_summary() {
+  printf "\n部署完成。\n"
+  printf "OpenClaw 版本: %s\n" "$OPENCLAW_VERSION"
+  printf "Gateway: ws://127.0.0.1:%s\n" "$OPENCLAW_GATEWAY_PORT"
+  printf "Gateway 日志: %s\n" "$GATEWAY_LOG"
+}
+
+print_summary() {
+  print_gateway_summary
+  printf "Office: http://127.0.0.1:%s\n" "$OPENCLAW_OFFICE_PORT"
+  printf "Office 日志: %s\n" "$OFFICE_LOG"
+}
+
+ensure_systemd
+ensure_node
+ensure_pnpm
+install_openclaw
+ensure_openclaw_config
+configure_gateway
+start_gateway_service
+wait_for_gateway
+install_office_dependencies
+build_office_if_needed
+
+if [[ "$OPENCLAW_SKIP_OFFICE_START" == "1" ]]; then
+  print_gateway_summary
+  exit 0
+fi
+
+start_office
+
+if ! wait_for_http "http://127.0.0.1:${OPENCLAW_OFFICE_PORT}" 60 2; then
+  echo "OpenClaw Office 启动失败，请检查日志：$OFFICE_LOG"
+  exit 1
+fi
+
+print_summary

--- a/start-openclaw-office.cmd
+++ b/start-openclaw-office.cmd
@@ -1,0 +1,10 @@
+@echo off
+setlocal
+powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0scripts\start-openclaw-office.ps1"
+set EXIT_CODE=%ERRORLEVEL%
+if not "%EXIT_CODE%"=="0" (
+  echo.
+  echo 启动失败，退出码 %EXIT_CODE%。
+  pause
+)
+exit /b %EXIT_CODE%


### PR DESCRIPTION
## Summary
- add a Windows double-click entrypoint for local OpenClaw Office startup
- bootstrap the WSL2 runtime for Node.js 22 and OpenClaw 2026.3.28 when required
- configure Gateway Control UI prerequisites and start the Gateway before Office launch
- start the Office HTTP process on Windows while reusing the Gateway runtime inside WSL2
- ignore local runtime and worktree directories in git

## Why
This change makes local setup much smoother on Windows machines that use WSL2 for the OpenClaw runtime. It removes the manual steps needed to install or repair the runtime, configure Gateway access for the Control UI, and bring up the Office frontend from a double-click launcher.

## Scope
### Windows side
- add `start-openclaw-office.cmd` as a double-click launcher
- add `scripts/start-openclaw-office.ps1` to:
  - select a usable WSL distro
  - ensure Node.js and OpenClaw are available in WSL2
  - run the bootstrap script in WSL2
  - read the Gateway token from the WSL config
  - launch `bin/openclaw-office.js` on Windows and open the browser

### WSL2 side
- add `scripts/wsl-bootstrap-openclaw-office.sh` to:
  - ensure systemd is enabled
  - install or upgrade Node.js 22.14+
  - install OpenClaw 2026.3.28
  - initialize OpenClaw config when missing
  - enable `gateway.controlUi.dangerouslyDisableDeviceAuth` and `gateway.controlUi.allowInsecureAuth`
  - install and restart the Gateway service with a fallback foreground start path
  - install frontend dependencies and build when needed
  - optionally skip Office startup so Windows can own the frontend process

### Repository hygiene
- ignore `.runtime/` and `.worktrees/`

## Validation
- [x] `wsl -d Ubuntu -- bash -lc 'cd /mnt/e/openclaw-office && pnpm test'`
- [x] `wsl -d Ubuntu -- bash -lc 'cd /mnt/e/openclaw-office && pnpm typecheck'`
- [x] `wsl -d Ubuntu -- bash -lc 'cd /mnt/e/openclaw-office && pnpm dlx oxlint src/'`
- [x] `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\start-openclaw-office.ps1`
- [x] verified Office responds on `http://127.0.0.1:5180`

## Notes
- `pnpm lint` is not directly runnable in the current WSL environment because `oxlint` is not installed as a local executable there; `pnpm dlx oxlint src/` was used as an equivalent verification path
- oxlint reports warnings only and no errors in the current codebase