### PR TITLE
feat(ui): re-point Setup GCP client to HQ sidecar over Tailscale (no bearer)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,8 @@
 # OpenClaw Office 环境变量
+
+# Branch customization
+# VITE_OFFICE_TITLE=OpenClaw Office
+# VITE_BRANCH_LABEL=SitioUno - Sucursal Miami
 # 复制此文件为 .env.local 并填入实际值
 
 # Gateway WebSocket 地址

--- a/.env.example
+++ b/.env.example
@@ -14,10 +14,12 @@ VITE_GATEWAY_TOKEN=
 # Mock 模式（设为 true 可不连接真实 Gateway 进行开发）
 # VITE_MOCK=true
 
-# --- Setup GCP (fleet-registry-api on Cloud Run) ---
-# Required by the "Setup GCP" console page (pairing requests + notification
-# channels). Both values can also be injected at runtime via
-# window.__OPENCLAW_CONFIG__.registryApiUrl / registryApiToken.
-# Treat the token as an admin credential — never commit a real value.
-# VITE_REGISTRY_API_URL=https://fleet-registry-api-XXXX.run.app
-# VITE_REGISTRY_API_TOKEN=
+# --- Setup GCP (HQ sidecar on Tailscale) ---
+# Used by the "Setup GCP" console page (pairing requests, notification
+# channels, notify broadcast). The trust boundary is the Tailscale VPN: the
+# HQ sidecar validates source identity server-side via `tailscale whois`,
+# so NO bearer token is required and none should ever be shipped in the
+# browser bundle. May also be injected at runtime via
+# window.__OPENCLAW_CONFIG__.registryApiUrl.
+# Default (when unset): http://openclaw-hq:8781
+# VITE_REGISTRY_API_URL=http://openclaw-hq:8781

--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,11 @@ VITE_GATEWAY_TOKEN=
 
 # Mock 模式（设为 true 可不连接真实 Gateway 进行开发）
 # VITE_MOCK=true
+
+# --- Setup GCP (fleet-registry-api on Cloud Run) ---
+# Required by the "Setup GCP" console page (pairing requests + notification
+# channels). Both values can also be injected at runtime via
+# window.__OPENCLAW_CONFIG__.registryApiUrl / registryApiToken.
+# Treat the token as an admin credential — never commit a real value.
+# VITE_REGISTRY_API_URL=https://fleet-registry-api-XXXX.run.app
+# VITE_REGISTRY_API_TOKEN=

--- a/ACP_PLAN.md
+++ b/ACP_PLAN.md
@@ -1,0 +1,13 @@
+# Tarea de Refactorización: WikiViewerModal
+**Contexto:** El fundador rechazó el componente WikiViewerModal.tsx actual. La UI con el grafo (react-force-graph-2d) es muy lenta, se superpone el botón de cerrar y la experiencia general es mala.
+
+**Objetivos:**
+1. Desinstalar `react-force-graph-2d` y `d3-force` usando pnpm.
+2. Refactorizar `src/components/console/agents/WikiViewerModal.tsx`:
+   - Elimina todo rastro del grafo y la variable `viewMode`.
+   - Crea un layout de dos columnas:
+     - Izquierda (Sidebar): Una lista de archivos mockeados (e.g., `index.md`, `SOUL.md`, `AGENTS.md`).
+     - Derecha (Main Content): Renderiza el texto Markdown simulado correspondiente al archivo seleccionado en la izquierda usando `react-markdown`.
+   - Repara el botón "X" de cerrar para que no quede montado sobre el título. Ponlo limpio en la esquina del modal.
+3. Asegúrate de compilar con `pnpm build` para revisar errores de TypeScript.
+4. Usa `git add .` y `git commit -m "refactor: Overhaul WikiViewer UX for fluid text-first navigation"`.

--- a/DEPLOY_LOCAL_NODES.md
+++ b/DEPLOY_LOCAL_NODES.md
@@ -1,0 +1,11 @@
+# Protocolo de Despliegue y Sincronización de Nodos Locales
+
+Este documento establece las reglas para los agentes DevOps locales (ej. Capablanca en Miami, o sus equivalentes en otras sucursales).
+
+## 1. Responsabilidad Estricta
+Ningún agente DevOps local debe intentar conectarse por SSH, Bastion o VPN para hacer despliegues en infraestructura externa (HQ u otros nodos). Cada nodo debe tener su propio agente vigilante que haga un `pull` de este repositorio y compile los binarios localmente.
+
+## 2. Sincronización de Skills Locales
+La carpeta `/local-skills` dentro de este repositorio actúa como el canal de distribución para custom skills entre sucursales.
+- **Acción requerida (DevOps Local):** Monitorear esta carpeta. Si hay cambios o nuevos skills, el agente debe copiarlos al directorio global local del nodo (`~/.local/npm-global/lib/node_modules/openclaw/skills/` o equivalente) para que OpenClaw los registre en el Gateway.
+- Si un agente en un nodo crea un skill útil, el DevOps de ese nodo debe hacerle commit y push hacia esta carpeta `/local-skills` para compartirlo con el ecosistema.

--- a/NODE_ONBOARDING.md
+++ b/NODE_ONBOARDING.md
@@ -1,0 +1,27 @@
+# Guía de Onboarding para Nuevos Nodos (SitioUno)
+
+Esta es la guía oficial para acoplar una nueva sucursal o nodo a la arquitectura unificada de **SitioUno**. Siguiendo estos pasos, el nuevo nodo heredará todas las customizaciones (branding neón, interfaz de skills locales, etc.) y compartirá la base de conocimiento global.
+
+## Paso 1: Clonar este Repositorio Base
+En el workspace del agente programador del nuevo nodo, ejecuta:
+```bash
+git clone https://github.com/sitiouno/openclaw-office.git
+```
+
+## Paso 2: Crear al DevOps (Capablanca)
+Todo nodo DEBE tener un agente llamado **Capablanca** dedicado a operaciones domésticas y de sistema.
+1. Revisa `docs/ecosystem_agents/CAPABLANCA_DEVOPS.md`.
+2. Utiliza la skill `prompt-architect` para generar sus archivos `IDENTITY.md`, `SOUL.md` y `AGENTS.md` con ese formato.
+
+## Paso 3: Instalar Skills Locales
+1. Capablanca debe entrar a `/local-skills` dentro de este repo.
+2. Copiar todo el contenido a su carpeta global de sistema:
+   `cp -R local-skills/* ~/.local/npm-global/lib/node_modules/openclaw/skills/`
+3. Reiniciar el gateway de OpenClaw. A partir de este momento, el nodo tiene acceso a `prompt-architect`, `llm-wiki`, etc.
+
+## Paso 4: Despliegue de la Interfaz Customizada
+1. Capablanca debe crear un script `deploy-office.sh` que ejecute `pnpm build` en este repo y copie el `/dist` a la ruta global del OpenClaw Office local.
+2. Capablanca debe tener un `cron` asignado para que ejecute este sync automáticamente.
+
+## Paso 5: El Programador
+El nodo puede tener su propio programador o mantener el nombre "Alekhine". Su perfil debe configurarse leyendo `docs/ecosystem_agents/ARCHITECT_PROGRAMMER.md`. Este agente tendrá la misión de vigilar los repositorios y programar las herramientas específicas que requiera su sucursal, haciendo push a este repositorio para beneficio de todos.

--- a/UPSTREAM_MERGE_POLICY.md
+++ b/UPSTREAM_MERGE_POLICY.md
@@ -1,0 +1,22 @@
+# Política de Mantenimiento de Fork (Upstream Merge Policy)
+
+**Propietario / Responsable Técnico:** Alekhine (Erudito)
+**Frecuencia de Revisión:** Semanal (vía CronJob)
+**Upstream:** `https://github.com/WW-AI-Lab/openclaw-office.git`
+
+Este repositorio es un **fork productivo** adaptado para las necesidades específicas de la sucursal Miami y la red global de *SitioUno*. Contiene customizaciones de marca (Branding Neón) y lógicas estructurales de arquitectura local (Local Skills, etc.).
+
+## 1. Misión de Mantenimiento
+Alekhine debe revisar semanalmente los commits del repositorio original (Upstream) para incorporar parches de seguridad, optimizaciones de rendimiento y nuevos componentes estructurales que la comunidad oficial desarrolle.
+
+## 2. Regla de Oro (Resolución de Conflictos)
+Si un cambio oficial entra en conflicto con una modificación arquitectónica o visual creada por nosotros (ej. `TopBar.tsx` branding, `agents-store.ts` tabs):
+- **PREVALECEN LOS CAMBIOS LOCALES.** Nuestras customizaciones no son negociables y no deben ser sobreescritas por el código vanilla.
+- Alekhine debe aislar el código vanilla útil y adaptarlo a nuestro diseño, descartando la sobreescritura de nuestra UI.
+
+## 3. Protocolo de Escalamiento (Escalation Path)
+Si un refactor masivo de upstream rompe la compatibilidad estructural de nuestras vistas custom de tal forma que la resolución automática o el análisis estático de Alekhine sea inseguro:
+1. **Pausa el merge.** No enviar a rama `main`.
+2. **Notificar a Murphy (Foreman).** Murphy evaluará el impacto.
+3. Si requiere reevaluación de arquitectura, Murphy lo pasará al Granmaster (Advisor Consult).
+4. Como última instancia, el issue se escalará al CEO (Jean) para una decisión de negocio.

--- a/docs/ecosystem_agents/ARCHITECT_PROGRAMMER.md
+++ b/docs/ecosystem_agents/ARCHITECT_PROGRAMMER.md
@@ -1,0 +1,37 @@
+# Estándar de Agente Programador/Erudito
+
+Aunque el nombre del agente programador puede variar por nodo (ej. Alekhine en Miami), su comportamiento y capacidades deben regirse por este Blueprint de Alta Densidad para garantizar código SOLID y Cloud-native.
+
+## SOUL.md (Plantilla Base)
+```markdown
+<identity>
+Eres el Arquitecto Principal y "Erudito" del código de esta sucursal de SitioUno.
+Tu mente opera bajo los más altos estándares de ingeniería: principios SOLID, Clean Architecture, y seguridad por diseño.
+</identity>
+
+<communication_style>
+- **Precisión Quirúrgica:** Respuestas densas en valor, sin validaciones conversacionales.
+- **Enfoque Pragmático:** Diseñas para producción. Evalúas trade-offs (costo, latencia) antes de codificar.
+- **Autoridad Técnica:** Si un diseño propuesto tiene fallas, lo señalas y propones la solución óptima.
+</communication_style>
+
+<behavioral_constraints>
+- NUNCA uses código deprecated o inseguro.
+- SIEMPRE asume infraestructura escalable.
+- Para cambios en el frontend de OpenClaw Office, respeta SIEMPRE el `UPSTREAM_MERGE_POLICY.md` (las customizaciones de SitioUno tienen prioridad).
+</behavioral_constraints>
+```
+
+## AGENTS.md (Plantilla Base)
+```markdown
+<role>
+Arquitecto de Sistemas & Programador Avanzado
+Model: Modelos de alto razonamiento profundo (pro/reasoning)
+</role>
+
+<capabilities>
+1. Cloud & Infra: GCP, Docker.
+2. Desarrollo: TypeScript (React/Vite/Zustand), Python (Asyncio).
+3. Ecosistema: OpenClaw nativo.
+</capabilities>
+```

--- a/docs/ecosystem_agents/CAPABLANCA_DEVOPS.md
+++ b/docs/ecosystem_agents/CAPABLANCA_DEVOPS.md
@@ -1,0 +1,51 @@
+# Estándar de Agente DevOps: Capablanca
+
+Para simplificar la infraestructura del ecosistema de SitioUno, **todos los nodos** deben tener un agente llamado `Capablanca` encargado exclusivamente de tareas DevOps y despliegue local.
+
+## IDENTITY.md
+```markdown
+---
+name: Capablanca
+theme: system
+emoji: ♞
+---
+```
+
+## SOUL.md
+```markdown
+<identity>
+Eres Capablanca, el DevOps y Supervisor de Pipelines de la Sucursal para SitioUno.
+Tu filosofía es la automatización limpia y la vigilancia continua. Operas en las sombras asegurando que el código de los desarrolladores fluya desde el repositorio hasta producción sin fricción.
+</identity>
+
+<communication_style>
+- **Conciso y Mecánico:** Reportas estados (UP, DOWN, SYNCED).
+- **Tolerancia Cero al Error:** Si un despliegue rompe, aplicas rollback.
+- **Verbosidad Mínima:** "Despliegue exitoso. Commit [hash]."
+</communication_style>
+
+<behavioral_constraints>
+- NUNCA subas a producción código que no haya pasado linting/tests.
+- SIEMPRE que configures un cron, documéntalo en el log del nodo.
+- El despliegue a la UI Office se hace mediante bash scripting e inyección directa en ~/.local/npm-global/lib/node_modules/.
+</behavioral_constraints>
+```
+
+## AGENTS.md
+```markdown
+<role>
+Ingeniero DevOps y Vigilante de Pipelines (Doméstico)
+ID: `capablanca` | Model: Modelos rápidos y deterministas (ej. flash)
+</role>
+
+<capabilities>
+1. CI/CD Local: Git, Bash scripting, systemd.
+2. Orquestación: Manejo de crons para vigilar repositorios.
+3. Monitoreo: Uso de curl y tail logs.
+</capabilities>
+
+<workflow_rules>
+- Ejecutar scripts de deploy local (ej. `deploy-office.sh`).
+- Monitorear la carpeta `/local-skills` del repositorio. Si hay skills nuevos, copiarlos al directorio global local del nodo (`~/.local/npm-global/lib/node_modules/openclaw/skills/`). Si tu nodo crea skills, haz commit y súbelos para compartir.
+</workflow_rules>
+```

--- a/local-skills/llm-wiki/SKILL.md
+++ b/local-skills/llm-wiki/SKILL.md
@@ -1,0 +1,24 @@
+<skill>
+  <name>llm-wiki</name>
+  <description>Implementa el patrón de base de conocimiento persistente basado en Markdown (Karpathy 'llm-wiki'). Permite a un agente crear, mantener y consultar una Wiki para un proyecto o para todo el ecosistema. Mantiene un index.md (catálogo) y un log.md (registro cronológico), e integra nueva información sin sobrescribir o perder contexto previo.</description>
+</skill>
+
+# Patrón LLM-Wiki (Knowledge Base Persistente)
+
+## 1. Anatomía de la Wiki
+Cualquier instancia de Wiki debe contener:
+- `/raw`: Directorio para fuentes inmutables (artículos, transcripciones, datos crudos).
+- `index.md`: Catálogo de todas las páginas de la wiki, agrupadas por categorías, con descripciones de 1 línea.
+- `log.md`: Registro cronológico ("append-only") de operaciones. Formato: `## [YYYY-MM-DD] accion | Target`.
+- `/*.md`: Páginas de entidades, conceptos, resúmenes e integraciones.
+
+## 2. Flujo de Ingesta (Ingest)
+Cuando se agrega una fuente:
+1. El agente lee el documento original en `/raw`.
+2. Extrae las ideas clave, conceptos y entidades.
+3. Actualiza o crea páginas `.md` en la wiki interconectándolas (cross-references).
+4. Actualiza el `index.md` si se crearon páginas nuevas.
+5. Añade una entrada al final de `log.md`.
+
+## 3. Escalabilidad
+Este patrón puede instanciarse a nivel global (ej. `~/openclaw-workspaces/wiki-global`) o dentro de un repositorio de código específico (ej. `/src/docs/wiki`).

--- a/local-skills/prompt-architect/SKILL.md
+++ b/local-skills/prompt-architect/SKILL.md
@@ -1,0 +1,18 @@
+<skill>
+  <name>prompt-architect</name>
+  <description>Skill activa de ingeniería de prompts de alta densidad. Utiliza estructuras XML (<identity>, <instructions>, <constraints>, <context>), delimitación de roles estrictos y control de verbosidad basado en los leaks de Codex/Claude y la arquitectura OpenClaw. Úsala para reescribir perfiles de agentes (AGENTS.md, SOUL.md, etc.) asegurando máxima obediencia, seguridad y capacidad analítica.</description>
+</skill>
+
+# Arquitectura de Prompts de Alta Densidad (Prompt Architect)
+
+## 1. Principios Core
+- **Cadena de Mando:** El `developer` manda. El prompt define la identidad y el estado operacional antes de cualquier input del `user`.
+- **Delimitación XML:** Todo contexto, instrucción o ejemplo debe estar en tags (`<identity>`, `<rules>`, `<workspace>`, `<tools>`).
+- **Verbosidad Calibrada:** Instruir al modelo explícitamente a omitir validaciones sociales (e.g. "Entendido", "Aquí tienes").
+
+## 2. Estructura Estándar para Agentes OpenClaw
+Todo perfil de agente debe contener:
+- `<role>`: Quién es y su función en la red.
+- `<capabilities>`: Qué sabe hacer (lenguajes, frameworks, integraciones).
+- `<constraints>`: Límites de seguridad duros.
+- `<output_format>`: Cómo debe hablar y entregar resultados.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ww-ai-lab/openclaw-office",
-  "version": "2026.4.10-2",
+  "version": "2026.4.25-1",
   "description": "Visual monitoring & management frontend for OpenClaw Multi-Agent system",
   "keywords": [
     "ai-agents",

--- a/package.json
+++ b/package.json
@@ -47,14 +47,12 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "d3-force": "^3.0.0",
     "i18next": "^25.8.13",
     "i18next-browser-languagedetector": "^8.2.1",
     "immer": "^10.1.1",
     "lucide-react": "^0.575.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "react-force-graph-2d": "^1.29.1",
     "react-i18next": "^16.5.4",
     "react-markdown": "^10.1.0",
     "react-router-dom": "^7.13.1",

--- a/package.json
+++ b/package.json
@@ -47,12 +47,14 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "d3-force": "^3.0.0",
     "i18next": "^25.8.13",
     "i18next-browser-languagedetector": "^8.2.1",
     "immer": "^10.1.1",
     "lucide-react": "^0.575.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-force-graph-2d": "^1.29.1",
     "react-i18next": "^16.5.4",
     "react-markdown": "^10.1.0",
     "react-router-dom": "^7.13.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     dependencies:
-      d3-force:
-        specifier: ^3.0.0
-        version: 3.0.0
       i18next:
         specifier: ^25.8.13
         version: 25.8.14(typescript@5.9.3)
@@ -29,9 +26,6 @@ importers:
       react-dom:
         specifier: ^19.1.0
         version: 19.2.4(react@19.2.4)
-      react-force-graph-2d:
-        specifier: ^1.29.1
-        version: 1.29.1(react@19.2.4)
       react-i18next:
         specifier: ^16.5.4
         version: 16.5.5(i18next@25.8.14(typescript@5.9.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
@@ -644,9 +638,6 @@ packages:
       '@types/react-dom':
         optional: true
 
-  '@tweenjs/tween.js@25.0.0':
-    resolution: {integrity: sha512-XKLA6syeBUaPzx4j3qwMqzzq+V4uo72BnlbOjmuljLrRqdsd3qnzvZZoxvMHZ23ndsRS4aufU6JOZYpCbU6T1A==}
-
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
@@ -765,10 +756,6 @@ packages:
   '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
 
-  accessor-fn@1.5.3:
-    resolution: {integrity: sha512-rkAofCwe/FvYFUlMB0v0gWmhqtfAtV1IUkdPbfhTUyYniu5LrC0A0UJkTH0Jv3S8SvwkmfuAlY+mQIJATdocMA==}
-    engines: {node: '>=12'}
-
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
@@ -800,9 +787,6 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  bezier-js@6.1.4:
-    resolution: {integrity: sha512-PA0FW9ZpcHbojUCMu28z9Vg/fNkwTj5YhusSAjHHDfHDGLxJ6YUKrAN2vk1fP2MMOxVw4Oko16FMlRGVBGqLKg==}
-
   browserslist@4.28.1:
     resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
@@ -814,10 +798,6 @@ packages:
 
   caniuse-lite@1.0.30001774:
     resolution: {integrity: sha512-DDdwPGz99nmIEv216hKSgLD+D4ikHQHjBC/seF98N9CPqRX4M5mSxT9eTV6oyisnJcuzxtZy4n17yKKQYmYQOA==}
-
-  canvas-color-tracker@1.3.2:
-    resolution: {integrity: sha512-ryQkDX26yJ3CXzb3hxUVNlg1NKE4REc5crLBq661Nxzr8TNd236SaEf2ffYLXyI5tSABSeguHLqcVq4vf9L3Zg==}
-    engines: {node: '>=12'}
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -870,31 +850,12 @@ packages:
     resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
     engines: {node: '>=12'}
 
-  d3-binarytree@1.0.2:
-    resolution: {integrity: sha512-cElUNH+sHu95L04m92pG73t2MEJXKu+GeKUN1TJkFsu93E5W8E9Sc3kHEGJKgenGvj19m6upSn2EunvMgMD2Yw==}
-
   d3-color@3.1.0:
     resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
     engines: {node: '>=12'}
 
-  d3-dispatch@3.0.1:
-    resolution: {integrity: sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==}
-    engines: {node: '>=12'}
-
-  d3-drag@3.0.0:
-    resolution: {integrity: sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==}
-    engines: {node: '>=12'}
-
   d3-ease@3.0.1:
     resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
-    engines: {node: '>=12'}
-
-  d3-force-3d@3.0.6:
-    resolution: {integrity: sha512-4tsKHUPLOVkyfEffZo1v6sFHvGFwAIIjt/W8IThbp08DYAsXZck+2pSHEG5W1+gQgEvFLdZkYvmJAbRM2EzMnA==}
-    engines: {node: '>=12'}
-
-  d3-force@3.0.0:
-    resolution: {integrity: sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==}
     engines: {node: '>=12'}
 
   d3-format@3.1.2:
@@ -905,27 +866,12 @@ packages:
     resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
     engines: {node: '>=12'}
 
-  d3-octree@1.1.0:
-    resolution: {integrity: sha512-F8gPlqpP+HwRPMO/8uOu5wjH110+6q4cgJvgJT6vlpy3BEaDIKlTZrgHKZSp/i1InRpVfh4puY/kvL6MxK930A==}
-
   d3-path@3.1.0:
     resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
     engines: {node: '>=12'}
 
-  d3-quadtree@3.0.1:
-    resolution: {integrity: sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==}
-    engines: {node: '>=12'}
-
-  d3-scale-chromatic@3.1.0:
-    resolution: {integrity: sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==}
-    engines: {node: '>=12'}
-
   d3-scale@4.0.2:
     resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
-    engines: {node: '>=12'}
-
-  d3-selection@3.0.0:
-    resolution: {integrity: sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==}
     engines: {node: '>=12'}
 
   d3-shape@3.2.0:
@@ -942,16 +888,6 @@ packages:
 
   d3-timer@3.0.1:
     resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
-    engines: {node: '>=12'}
-
-  d3-transition@3.0.1:
-    resolution: {integrity: sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==}
-    engines: {node: '>=12'}
-    peerDependencies:
-      d3-selection: 2 - 3
-
-  d3-zoom@3.0.0:
-    resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
     engines: {node: '>=12'}
 
   data-urls@5.0.0:
@@ -1060,14 +996,6 @@ packages:
       picomatch:
         optional: true
 
-  float-tooltip@1.7.5:
-    resolution: {integrity: sha512-/kXzuDnnBqyyWyhDMH7+PfP8J/oXiAavGzcRxASOMRHFuReDtofizLLJsf7nnDLAfEaMW4pVWaXrAjtnglpEkg==}
-    engines: {node: '>=12'}
-
-  force-graph@1.51.4:
-    resolution: {integrity: sha512-TdJ2KbkoiDQ7NIRx8IPGD0mAXXpLhamS7c+b7W98b0MHG7lphnda1VOQX/98UDTsttIAdH4TcP0l0MauSnLK8w==}
-    engines: {node: '>=12'}
-
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1126,10 +1054,6 @@ packages:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
 
-  index-array-by@1.4.2:
-    resolution: {integrity: sha512-SP23P27OUKzXWEC/TOyWlwLviofQkCSCKONnc62eItjp69yCZZPqDQtr3Pw5gJDnPeUMqExmKydNZaJO0FU9pw==}
-    engines: {node: '>=12'}
-
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
 
@@ -1155,10 +1079,6 @@ packages:
 
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
-
-  jerrypick@1.1.2:
-    resolution: {integrity: sha512-YKnxXEekXKzhpf7CLYA0A+oDP8V0OhICNCr5lv96FvSsDEmrb0GKM776JgQvHTMjr7DTTPEVv/1Ciaw0uEWzBA==}
-    engines: {node: '>=12'}
 
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
@@ -1188,10 +1108,6 @@ packages:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
     hasBin: true
-
-  kapsule@1.16.3:
-    resolution: {integrity: sha512-4+5mNNf4vZDSwPhKprKwz3330iisPrb08JyMgbsdFrimBCKNHecua/WBwvVg3n7vwx0C1ARjfhwIpbrbd9n5wg==}
-    engines: {node: '>=12'}
 
   lightningcss-android-arm64@1.31.1:
     resolution: {integrity: sha512-HXJF3x8w9nQ4jbXRiNppBCqeZPIAfUo8zE/kOEGbW5NZvGc/K7nMxbhIr+YlFlHW5mpbg/YFPdbnCh1wAXCKFg==}
@@ -1266,9 +1182,6 @@ packages:
   lightningcss@1.31.1:
     resolution: {integrity: sha512-l51N2r93WmGUye3WuFoN5k10zyvrVs0qfKBhyC5ogUQ6Ew6JUSswh78mbSO+IU3nTWsyOArqPCcShdQSadghBQ==}
     engines: {node: '>= 12.0.0'}
-
-  lodash-es@4.18.1:
-    resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
 
   lodash@4.17.23:
     resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
@@ -1479,9 +1392,6 @@ packages:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
 
-  preact@10.29.1:
-    resolution: {integrity: sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==}
-
   pretty-format@27.5.1:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
@@ -1500,12 +1410,6 @@ packages:
     resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
     peerDependencies:
       react: ^19.2.4
-
-  react-force-graph-2d@1.29.1:
-    resolution: {integrity: sha512-1Rl/1Z3xy2iTHKj6a0jRXGyiI86xUti81K+jBQZ+Oe46csaMikp47L5AjrzA9hY9fNGD63X8ffrqnvaORukCuQ==}
-    engines: {node: '>=12'}
-    peerDependencies:
-      react: '*'
 
   react-i18next@16.5.5:
     resolution: {integrity: sha512-5Z35e2JMALNR16FK/LDNQoAatQTVuO/4m4uHrIzewOPXIyf75gAHzuNLSWwmj5lRDJxDvXRJDECThkxWSAReng==}
@@ -1531,12 +1435,6 @@ packages:
 
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
-
-  react-kapsule@2.5.7:
-    resolution: {integrity: sha512-kifAF4ZPD77qZKc4CKLmozq6GY1sBzPEJTIJb0wWFK6HsePJatK3jXplZn2eeAt3x67CDozgi7/rO8fNQ/AL7A==}
-    engines: {node: '>=12'}
-    peerDependencies:
-      react: '>=16.13.1'
 
   react-markdown@10.1.0:
     resolution: {integrity: sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==}
@@ -1685,9 +1583,6 @@ packages:
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
-
-  tinycolor2@1.6.0:
-    resolution: {integrity: sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==}
 
   tinyexec@0.3.2:
     resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
@@ -2362,8 +2257,6 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@tweenjs/tween.js@25.0.0': {}
-
   '@types/aria-query@5.0.4': {}
 
   '@types/babel__core@7.20.5':
@@ -2506,8 +2399,6 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 2.0.0
 
-  accessor-fn@1.5.3: {}
-
   agent-base@7.1.4: {}
 
   ansi-regex@5.0.1: {}
@@ -2526,8 +2417,6 @@ snapshots:
 
   baseline-browser-mapping@2.10.0: {}
 
-  bezier-js@6.1.4: {}
-
   browserslist@4.28.1:
     dependencies:
       baseline-browser-mapping: 2.10.0
@@ -2539,10 +2428,6 @@ snapshots:
   cac@6.7.14: {}
 
   caniuse-lite@1.0.30001774: {}
-
-  canvas-color-tracker@1.3.2:
-    dependencies:
-      tinycolor2: 1.6.0
 
   ccount@2.0.1: {}
 
@@ -2585,32 +2470,9 @@ snapshots:
     dependencies:
       internmap: 2.0.3
 
-  d3-binarytree@1.0.2: {}
-
   d3-color@3.1.0: {}
 
-  d3-dispatch@3.0.1: {}
-
-  d3-drag@3.0.0:
-    dependencies:
-      d3-dispatch: 3.0.1
-      d3-selection: 3.0.0
-
   d3-ease@3.0.1: {}
-
-  d3-force-3d@3.0.6:
-    dependencies:
-      d3-binarytree: 1.0.2
-      d3-dispatch: 3.0.1
-      d3-octree: 1.1.0
-      d3-quadtree: 3.0.1
-      d3-timer: 3.0.1
-
-  d3-force@3.0.0:
-    dependencies:
-      d3-dispatch: 3.0.1
-      d3-quadtree: 3.0.1
-      d3-timer: 3.0.1
 
   d3-format@3.1.2: {}
 
@@ -2618,16 +2480,7 @@ snapshots:
     dependencies:
       d3-color: 3.1.0
 
-  d3-octree@1.1.0: {}
-
   d3-path@3.1.0: {}
-
-  d3-quadtree@3.0.1: {}
-
-  d3-scale-chromatic@3.1.0:
-    dependencies:
-      d3-color: 3.1.0
-      d3-interpolate: 3.0.1
 
   d3-scale@4.0.2:
     dependencies:
@@ -2636,8 +2489,6 @@ snapshots:
       d3-interpolate: 3.0.1
       d3-time: 3.1.0
       d3-time-format: 4.1.0
-
-  d3-selection@3.0.0: {}
 
   d3-shape@3.2.0:
     dependencies:
@@ -2652,23 +2503,6 @@ snapshots:
       d3-array: 3.2.4
 
   d3-timer@3.0.1: {}
-
-  d3-transition@3.0.1(d3-selection@3.0.0):
-    dependencies:
-      d3-color: 3.1.0
-      d3-dispatch: 3.0.1
-      d3-ease: 3.0.1
-      d3-interpolate: 3.0.1
-      d3-selection: 3.0.0
-      d3-timer: 3.0.1
-
-  d3-zoom@3.0.0:
-    dependencies:
-      d3-dispatch: 3.0.1
-      d3-drag: 3.0.0
-      d3-interpolate: 3.0.1
-      d3-selection: 3.0.0
-      d3-transition: 3.0.1(d3-selection@3.0.0)
 
   data-urls@5.0.0:
     dependencies:
@@ -2770,30 +2604,6 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.3
 
-  float-tooltip@1.7.5:
-    dependencies:
-      d3-selection: 3.0.0
-      kapsule: 1.16.3
-      preact: 10.29.1
-
-  force-graph@1.51.4:
-    dependencies:
-      '@tweenjs/tween.js': 25.0.0
-      accessor-fn: 1.5.3
-      bezier-js: 6.1.4
-      canvas-color-tracker: 1.3.2
-      d3-array: 3.2.4
-      d3-drag: 3.0.0
-      d3-force-3d: 3.0.6
-      d3-scale: 4.0.2
-      d3-scale-chromatic: 3.1.0
-      d3-selection: 3.0.0
-      d3-zoom: 3.0.0
-      float-tooltip: 1.7.5
-      index-array-by: 1.4.2
-      kapsule: 1.16.3
-      lodash-es: 4.18.1
-
   fsevents@2.3.3:
     optional: true
 
@@ -2867,8 +2677,6 @@ snapshots:
 
   indent-string@4.0.0: {}
 
-  index-array-by@1.4.2: {}
-
   inline-style-parser@0.2.7: {}
 
   internmap@2.0.3: {}
@@ -2887,8 +2695,6 @@ snapshots:
   is-plain-obj@4.1.0: {}
 
   is-potential-custom-element-name@1.0.1: {}
-
-  jerrypick@1.1.2: {}
 
   jiti@2.6.1: {}
 
@@ -2926,10 +2732,6 @@ snapshots:
   jsesc@3.1.0: {}
 
   json5@2.2.3: {}
-
-  kapsule@1.16.3:
-    dependencies:
-      lodash-es: 4.18.1
 
   lightningcss-android-arm64@1.31.1:
     optional: true
@@ -2979,8 +2781,6 @@ snapshots:
       lightningcss-linux-x64-musl: 1.31.1
       lightningcss-win32-arm64-msvc: 1.31.1
       lightningcss-win32-x64-msvc: 1.31.1
-
-  lodash-es@4.18.1: {}
 
   lodash@4.17.23: {}
 
@@ -3394,8 +3194,6 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  preact@10.29.1: {}
-
   pretty-format@27.5.1:
     dependencies:
       ansi-regex: 5.0.1
@@ -3417,13 +3215,6 @@ snapshots:
       react: 19.2.4
       scheduler: 0.27.0
 
-  react-force-graph-2d@1.29.1(react@19.2.4):
-    dependencies:
-      force-graph: 1.51.4
-      prop-types: 15.8.1
-      react: 19.2.4
-      react-kapsule: 2.5.7(react@19.2.4)
-
   react-i18next@16.5.5(i18next@25.8.14(typescript@5.9.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3):
     dependencies:
       '@babel/runtime': 7.28.6
@@ -3440,11 +3231,6 @@ snapshots:
   react-is@17.0.2: {}
 
   react-is@18.3.1: {}
-
-  react-kapsule@2.5.7(react@19.2.4):
-    dependencies:
-      jerrypick: 1.1.2
-      react: 19.2.4
 
   react-markdown@10.1.0(@types/react@19.2.14)(react@19.2.4):
     dependencies:
@@ -3649,8 +3435,6 @@ snapshots:
   tiny-invariant@1.3.3: {}
 
   tinybench@2.9.0: {}
-
-  tinycolor2@1.6.0: {}
 
   tinyexec@0.3.2: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      d3-force:
+        specifier: ^3.0.0
+        version: 3.0.0
       i18next:
         specifier: ^25.8.13
         version: 25.8.14(typescript@5.9.3)
@@ -26,6 +29,9 @@ importers:
       react-dom:
         specifier: ^19.1.0
         version: 19.2.4(react@19.2.4)
+      react-force-graph-2d:
+        specifier: ^1.29.1
+        version: 1.29.1(react@19.2.4)
       react-i18next:
         specifier: ^16.5.4
         version: 16.5.5(i18next@25.8.14(typescript@5.9.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
@@ -638,6 +644,9 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@tweenjs/tween.js@25.0.0':
+    resolution: {integrity: sha512-XKLA6syeBUaPzx4j3qwMqzzq+V4uo72BnlbOjmuljLrRqdsd3qnzvZZoxvMHZ23ndsRS4aufU6JOZYpCbU6T1A==}
+
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
@@ -756,6 +765,10 @@ packages:
   '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
 
+  accessor-fn@1.5.3:
+    resolution: {integrity: sha512-rkAofCwe/FvYFUlMB0v0gWmhqtfAtV1IUkdPbfhTUyYniu5LrC0A0UJkTH0Jv3S8SvwkmfuAlY+mQIJATdocMA==}
+    engines: {node: '>=12'}
+
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
@@ -787,6 +800,9 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  bezier-js@6.1.4:
+    resolution: {integrity: sha512-PA0FW9ZpcHbojUCMu28z9Vg/fNkwTj5YhusSAjHHDfHDGLxJ6YUKrAN2vk1fP2MMOxVw4Oko16FMlRGVBGqLKg==}
+
   browserslist@4.28.1:
     resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
@@ -798,6 +814,10 @@ packages:
 
   caniuse-lite@1.0.30001774:
     resolution: {integrity: sha512-DDdwPGz99nmIEv216hKSgLD+D4ikHQHjBC/seF98N9CPqRX4M5mSxT9eTV6oyisnJcuzxtZy4n17yKKQYmYQOA==}
+
+  canvas-color-tracker@1.3.2:
+    resolution: {integrity: sha512-ryQkDX26yJ3CXzb3hxUVNlg1NKE4REc5crLBq661Nxzr8TNd236SaEf2ffYLXyI5tSABSeguHLqcVq4vf9L3Zg==}
+    engines: {node: '>=12'}
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -850,12 +870,31 @@ packages:
     resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
     engines: {node: '>=12'}
 
+  d3-binarytree@1.0.2:
+    resolution: {integrity: sha512-cElUNH+sHu95L04m92pG73t2MEJXKu+GeKUN1TJkFsu93E5W8E9Sc3kHEGJKgenGvj19m6upSn2EunvMgMD2Yw==}
+
   d3-color@3.1.0:
     resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
     engines: {node: '>=12'}
 
+  d3-dispatch@3.0.1:
+    resolution: {integrity: sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==}
+    engines: {node: '>=12'}
+
+  d3-drag@3.0.0:
+    resolution: {integrity: sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==}
+    engines: {node: '>=12'}
+
   d3-ease@3.0.1:
     resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-force-3d@3.0.6:
+    resolution: {integrity: sha512-4tsKHUPLOVkyfEffZo1v6sFHvGFwAIIjt/W8IThbp08DYAsXZck+2pSHEG5W1+gQgEvFLdZkYvmJAbRM2EzMnA==}
+    engines: {node: '>=12'}
+
+  d3-force@3.0.0:
+    resolution: {integrity: sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==}
     engines: {node: '>=12'}
 
   d3-format@3.1.2:
@@ -866,12 +905,27 @@ packages:
     resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
     engines: {node: '>=12'}
 
+  d3-octree@1.1.0:
+    resolution: {integrity: sha512-F8gPlqpP+HwRPMO/8uOu5wjH110+6q4cgJvgJT6vlpy3BEaDIKlTZrgHKZSp/i1InRpVfh4puY/kvL6MxK930A==}
+
   d3-path@3.1.0:
     resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
     engines: {node: '>=12'}
 
+  d3-quadtree@3.0.1:
+    resolution: {integrity: sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==}
+    engines: {node: '>=12'}
+
+  d3-scale-chromatic@3.1.0:
+    resolution: {integrity: sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==}
+    engines: {node: '>=12'}
+
   d3-scale@4.0.2:
     resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-selection@3.0.0:
+    resolution: {integrity: sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==}
     engines: {node: '>=12'}
 
   d3-shape@3.2.0:
@@ -888,6 +942,16 @@ packages:
 
   d3-timer@3.0.1:
     resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
+  d3-transition@3.0.1:
+    resolution: {integrity: sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      d3-selection: 2 - 3
+
+  d3-zoom@3.0.0:
+    resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
     engines: {node: '>=12'}
 
   data-urls@5.0.0:
@@ -996,6 +1060,14 @@ packages:
       picomatch:
         optional: true
 
+  float-tooltip@1.7.5:
+    resolution: {integrity: sha512-/kXzuDnnBqyyWyhDMH7+PfP8J/oXiAavGzcRxASOMRHFuReDtofizLLJsf7nnDLAfEaMW4pVWaXrAjtnglpEkg==}
+    engines: {node: '>=12'}
+
+  force-graph@1.51.4:
+    resolution: {integrity: sha512-TdJ2KbkoiDQ7NIRx8IPGD0mAXXpLhamS7c+b7W98b0MHG7lphnda1VOQX/98UDTsttIAdH4TcP0l0MauSnLK8w==}
+    engines: {node: '>=12'}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1054,6 +1126,10 @@ packages:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
 
+  index-array-by@1.4.2:
+    resolution: {integrity: sha512-SP23P27OUKzXWEC/TOyWlwLviofQkCSCKONnc62eItjp69yCZZPqDQtr3Pw5gJDnPeUMqExmKydNZaJO0FU9pw==}
+    engines: {node: '>=12'}
+
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
 
@@ -1079,6 +1155,10 @@ packages:
 
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
+  jerrypick@1.1.2:
+    resolution: {integrity: sha512-YKnxXEekXKzhpf7CLYA0A+oDP8V0OhICNCr5lv96FvSsDEmrb0GKM776JgQvHTMjr7DTTPEVv/1Ciaw0uEWzBA==}
+    engines: {node: '>=12'}
 
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
@@ -1108,6 +1188,10 @@ packages:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
     hasBin: true
+
+  kapsule@1.16.3:
+    resolution: {integrity: sha512-4+5mNNf4vZDSwPhKprKwz3330iisPrb08JyMgbsdFrimBCKNHecua/WBwvVg3n7vwx0C1ARjfhwIpbrbd9n5wg==}
+    engines: {node: '>=12'}
 
   lightningcss-android-arm64@1.31.1:
     resolution: {integrity: sha512-HXJF3x8w9nQ4jbXRiNppBCqeZPIAfUo8zE/kOEGbW5NZvGc/K7nMxbhIr+YlFlHW5mpbg/YFPdbnCh1wAXCKFg==}
@@ -1182,6 +1266,9 @@ packages:
   lightningcss@1.31.1:
     resolution: {integrity: sha512-l51N2r93WmGUye3WuFoN5k10zyvrVs0qfKBhyC5ogUQ6Ew6JUSswh78mbSO+IU3nTWsyOArqPCcShdQSadghBQ==}
     engines: {node: '>= 12.0.0'}
+
+  lodash-es@4.18.1:
+    resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
 
   lodash@4.17.23:
     resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
@@ -1392,6 +1479,9 @@ packages:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
 
+  preact@10.29.1:
+    resolution: {integrity: sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==}
+
   pretty-format@27.5.1:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
@@ -1410,6 +1500,12 @@ packages:
     resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
     peerDependencies:
       react: ^19.2.4
+
+  react-force-graph-2d@1.29.1:
+    resolution: {integrity: sha512-1Rl/1Z3xy2iTHKj6a0jRXGyiI86xUti81K+jBQZ+Oe46csaMikp47L5AjrzA9hY9fNGD63X8ffrqnvaORukCuQ==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      react: '*'
 
   react-i18next@16.5.5:
     resolution: {integrity: sha512-5Z35e2JMALNR16FK/LDNQoAatQTVuO/4m4uHrIzewOPXIyf75gAHzuNLSWwmj5lRDJxDvXRJDECThkxWSAReng==}
@@ -1435,6 +1531,12 @@ packages:
 
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
+
+  react-kapsule@2.5.7:
+    resolution: {integrity: sha512-kifAF4ZPD77qZKc4CKLmozq6GY1sBzPEJTIJb0wWFK6HsePJatK3jXplZn2eeAt3x67CDozgi7/rO8fNQ/AL7A==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      react: '>=16.13.1'
 
   react-markdown@10.1.0:
     resolution: {integrity: sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==}
@@ -1583,6 +1685,9 @@ packages:
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinycolor2@1.6.0:
+    resolution: {integrity: sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==}
 
   tinyexec@0.3.2:
     resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
@@ -2257,6 +2362,8 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
+  '@tweenjs/tween.js@25.0.0': {}
+
   '@types/aria-query@5.0.4': {}
 
   '@types/babel__core@7.20.5':
@@ -2399,6 +2506,8 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 2.0.0
 
+  accessor-fn@1.5.3: {}
+
   agent-base@7.1.4: {}
 
   ansi-regex@5.0.1: {}
@@ -2417,6 +2526,8 @@ snapshots:
 
   baseline-browser-mapping@2.10.0: {}
 
+  bezier-js@6.1.4: {}
+
   browserslist@4.28.1:
     dependencies:
       baseline-browser-mapping: 2.10.0
@@ -2428,6 +2539,10 @@ snapshots:
   cac@6.7.14: {}
 
   caniuse-lite@1.0.30001774: {}
+
+  canvas-color-tracker@1.3.2:
+    dependencies:
+      tinycolor2: 1.6.0
 
   ccount@2.0.1: {}
 
@@ -2470,9 +2585,32 @@ snapshots:
     dependencies:
       internmap: 2.0.3
 
+  d3-binarytree@1.0.2: {}
+
   d3-color@3.1.0: {}
 
+  d3-dispatch@3.0.1: {}
+
+  d3-drag@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-selection: 3.0.0
+
   d3-ease@3.0.1: {}
+
+  d3-force-3d@3.0.6:
+    dependencies:
+      d3-binarytree: 1.0.2
+      d3-dispatch: 3.0.1
+      d3-octree: 1.1.0
+      d3-quadtree: 3.0.1
+      d3-timer: 3.0.1
+
+  d3-force@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-quadtree: 3.0.1
+      d3-timer: 3.0.1
 
   d3-format@3.1.2: {}
 
@@ -2480,7 +2618,16 @@ snapshots:
     dependencies:
       d3-color: 3.1.0
 
+  d3-octree@1.1.0: {}
+
   d3-path@3.1.0: {}
+
+  d3-quadtree@3.0.1: {}
+
+  d3-scale-chromatic@3.1.0:
+    dependencies:
+      d3-color: 3.1.0
+      d3-interpolate: 3.0.1
 
   d3-scale@4.0.2:
     dependencies:
@@ -2489,6 +2636,8 @@ snapshots:
       d3-interpolate: 3.0.1
       d3-time: 3.1.0
       d3-time-format: 4.1.0
+
+  d3-selection@3.0.0: {}
 
   d3-shape@3.2.0:
     dependencies:
@@ -2503,6 +2652,23 @@ snapshots:
       d3-array: 3.2.4
 
   d3-timer@3.0.1: {}
+
+  d3-transition@3.0.1(d3-selection@3.0.0):
+    dependencies:
+      d3-color: 3.1.0
+      d3-dispatch: 3.0.1
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-timer: 3.0.1
+
+  d3-zoom@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
 
   data-urls@5.0.0:
     dependencies:
@@ -2604,6 +2770,30 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.3
 
+  float-tooltip@1.7.5:
+    dependencies:
+      d3-selection: 3.0.0
+      kapsule: 1.16.3
+      preact: 10.29.1
+
+  force-graph@1.51.4:
+    dependencies:
+      '@tweenjs/tween.js': 25.0.0
+      accessor-fn: 1.5.3
+      bezier-js: 6.1.4
+      canvas-color-tracker: 1.3.2
+      d3-array: 3.2.4
+      d3-drag: 3.0.0
+      d3-force-3d: 3.0.6
+      d3-scale: 4.0.2
+      d3-scale-chromatic: 3.1.0
+      d3-selection: 3.0.0
+      d3-zoom: 3.0.0
+      float-tooltip: 1.7.5
+      index-array-by: 1.4.2
+      kapsule: 1.16.3
+      lodash-es: 4.18.1
+
   fsevents@2.3.3:
     optional: true
 
@@ -2677,6 +2867,8 @@ snapshots:
 
   indent-string@4.0.0: {}
 
+  index-array-by@1.4.2: {}
+
   inline-style-parser@0.2.7: {}
 
   internmap@2.0.3: {}
@@ -2695,6 +2887,8 @@ snapshots:
   is-plain-obj@4.1.0: {}
 
   is-potential-custom-element-name@1.0.1: {}
+
+  jerrypick@1.1.2: {}
 
   jiti@2.6.1: {}
 
@@ -2732,6 +2926,10 @@ snapshots:
   jsesc@3.1.0: {}
 
   json5@2.2.3: {}
+
+  kapsule@1.16.3:
+    dependencies:
+      lodash-es: 4.18.1
 
   lightningcss-android-arm64@1.31.1:
     optional: true
@@ -2781,6 +2979,8 @@ snapshots:
       lightningcss-linux-x64-musl: 1.31.1
       lightningcss-win32-arm64-msvc: 1.31.1
       lightningcss-win32-x64-msvc: 1.31.1
+
+  lodash-es@4.18.1: {}
 
   lodash@4.17.23: {}
 
@@ -3194,6 +3394,8 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  preact@10.29.1: {}
+
   pretty-format@27.5.1:
     dependencies:
       ansi-regex: 5.0.1
@@ -3215,6 +3417,13 @@ snapshots:
       react: 19.2.4
       scheduler: 0.27.0
 
+  react-force-graph-2d@1.29.1(react@19.2.4):
+    dependencies:
+      force-graph: 1.51.4
+      prop-types: 15.8.1
+      react: 19.2.4
+      react-kapsule: 2.5.7(react@19.2.4)
+
   react-i18next@16.5.5(i18next@25.8.14(typescript@5.9.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3):
     dependencies:
       '@babel/runtime': 7.28.6
@@ -3231,6 +3440,11 @@ snapshots:
   react-is@17.0.2: {}
 
   react-is@18.3.1: {}
+
+  react-kapsule@2.5.7(react@19.2.4):
+    dependencies:
+      jerrypick: 1.1.2
+      react: 19.2.4
 
   react-markdown@10.1.0(@types/react@19.2.14)(react@19.2.4):
     dependencies:
@@ -3435,6 +3649,8 @@ snapshots:
   tiny-invariant@1.3.3: {}
 
   tinybench@2.9.0: {}
+
+  tinycolor2@1.6.0: {}
 
   tinyexec@0.3.2: {}
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import { CronPage } from "@/components/pages/CronPage";
 import { DashboardPage } from "@/components/pages/DashboardPage";
 import { ChatPage } from "@/components/pages/ChatPage";
 import { SettingsPage } from "@/components/pages/SettingsPage";
+import { SetupGcpPage } from "@/components/pages/SetupGcpPage";
 import { SkillsPage } from "@/components/pages/SkillsPage";
 import { ChatWorkspaceBootstrap } from "@/components/chat/ChatWorkspaceBootstrap";
 import type { PageId } from "@/gateway/types";
@@ -39,6 +40,7 @@ const PAGE_MAP: Record<string, PageId> = {
   "/channels": "channels",
   "/skills": "skills",
   "/cron": "cron",
+  "/setup-gcp": "setupGcp",
   "/settings": "settings",
 };
 
@@ -111,6 +113,7 @@ export function App() {
           <Route path="/channels" element={<ChannelsPage />} />
           <Route path="/skills" element={<SkillsPage />} />
           <Route path="/cron" element={<CronPage />} />
+          <Route path="/setup-gcp" element={<SetupGcpPage />} />
           <Route path="/settings" element={<SettingsPage />} />
         </Route>
         <Route path="*" element={<Navigate to="/" replace />} />

--- a/src/components/console/agents/AgentDetailTabs.tsx
+++ b/src/components/console/agents/AgentDetailTabs.tsx
@@ -3,6 +3,7 @@ import type { AgentSummary } from "@/gateway/types";
 import { useAgentsStore, type AgentTab } from "@/store/console-stores/agents-store";
 import { ChannelsTab } from "./tabs/ChannelsTab";
 import { CronJobsTab } from "./tabs/CronJobsTab";
+import { LocalSkillsTab } from "./LocalSkillsTab";
 import { FilesTab } from "./tabs/FilesTab";
 import { OverviewTab } from "./tabs/OverviewTab";
 import { SkillsTab } from "./tabs/SkillsTab";
@@ -46,7 +47,7 @@ export function AgentDetailTabs({ agent }: AgentDetailTabsProps) {
         {activeTab === "skills" && <SkillsTab key={agent.id} agent={agent} />}
         {activeTab === "channels" && <ChannelsTab key={agent.id} agent={agent} />}
         {activeTab === "cronJobs" && <CronJobsTab key={agent.id} agent={agent} />}
-        {activeTab === "local_skills" && <LocalSkillsTab key={agent.id} agent={agent} />}
+        {activeTab === "local_skills" && <LocalSkillsTab key={agent.id} />}
       </div>
     </div>
   );

--- a/src/components/console/agents/AgentDetailTabs.tsx
+++ b/src/components/console/agents/AgentDetailTabs.tsx
@@ -8,7 +8,7 @@ import { OverviewTab } from "./tabs/OverviewTab";
 import { SkillsTab } from "./tabs/SkillsTab";
 import { ToolsTab } from "./tabs/ToolsTab";
 
-const TABS: AgentTab[] = ["overview", "files", "tools", "skills", "channels", "cronJobs"];
+const TABS: AgentTab[] = ["overview", "files", "tools", "skills", "local_skills", "channels", "cronJobs"];
 
 interface AgentDetailTabsProps {
   agent: AgentSummary;
@@ -46,6 +46,7 @@ export function AgentDetailTabs({ agent }: AgentDetailTabsProps) {
         {activeTab === "skills" && <SkillsTab key={agent.id} agent={agent} />}
         {activeTab === "channels" && <ChannelsTab key={agent.id} agent={agent} />}
         {activeTab === "cronJobs" && <CronJobsTab key={agent.id} agent={agent} />}
+        {activeTab === "local_skills" && <LocalSkillsTab key={agent.id} agent={agent} />}
       </div>
     </div>
   );

--- a/src/components/console/agents/AgentDetailTabs.tsx
+++ b/src/components/console/agents/AgentDetailTabs.tsx
@@ -47,7 +47,7 @@ export function AgentDetailTabs({ agent }: AgentDetailTabsProps) {
         {activeTab === "skills" && <SkillsTab key={agent.id} agent={agent} />}
         {activeTab === "channels" && <ChannelsTab key={agent.id} agent={agent} />}
         {activeTab === "cronJobs" && <CronJobsTab key={agent.id} agent={agent} />}
-        {activeTab === "local_skills" && <LocalSkillsTab key={agent.id} />}
+        {activeTab === "local_skills" && <LocalSkillsTab key={agent.id} agent={agent} />}
       </div>
     </div>
   );

--- a/src/components/console/agents/LocalSkillsTab.tsx
+++ b/src/components/console/agents/LocalSkillsTab.tsx
@@ -25,7 +25,7 @@ export function LocalSkillsTab({ agent }: LocalSkillsTabProps) {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ 
-          command: `xdg-open "obsidian://open?path=${vaultPath}"`,
+          command: `xdg-open "obsidian://open?vault=${agent.id}" || xdg-open "obsidian://open?path=${vaultPath}"`,
           background: true 
         })
       });

--- a/src/components/console/agents/LocalSkillsTab.tsx
+++ b/src/components/console/agents/LocalSkillsTab.tsx
@@ -8,30 +8,9 @@ interface LocalSkillsTabProps {
 }
 
 export function LocalSkillsTab({ agent }: LocalSkillsTabProps) {
-  const [opening, setOpening] = useState(false);
+  const opening = false;
   const [isWikiOpen, setIsWikiOpen] = useState(false);
 
-  const handleOpenObsidian = async () => {
-    setOpening(true);
-    try {
-      // Usar URI explícita compatible con Obsidian URI router 
-      // El nombre del vault en Obsidian suele coincidir con el nombre de la carpeta final
-      const vaultName = encodeURIComponent(agent.id);
-      
-      await fetch(`/api/v1/agents/${agent.id}/tools/exec`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ 
-          command: `xdg-open "obsidian://open?vault=${vaultName}" || xdg-open "obsidian://open?path=/home/magnus-vaos/openclaw-workspaces/${agent.id}"`,
-          background: true 
-        })
-      });
-    } catch (e) {
-      console.error(e);
-    } finally {
-      setTimeout(() => setOpening(false), 1000);
-    }
-  };
 
   return (
     <div className="space-y-6">

--- a/src/components/console/agents/LocalSkillsTab.tsx
+++ b/src/components/console/agents/LocalSkillsTab.tsx
@@ -25,7 +25,7 @@ export function LocalSkillsTab({ agent }: LocalSkillsTabProps) {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ 
-          command: `xdg-open "obsidian://open?vault=${agent.id}" || xdg-open "obsidian://open?path=${vaultPath}"`,
+          command: `obsidian`,
           background: true 
         })
       });

--- a/src/components/console/agents/LocalSkillsTab.tsx
+++ b/src/components/console/agents/LocalSkillsTab.tsx
@@ -1,0 +1,50 @@
+import { GatewayAgentEntry } from "@/gateway/types";
+import { Info } from "lucide-react";
+import { useTranslation } from "react-i18next";
+
+interface LocalSkillsTabProps {
+  agent: GatewayAgentEntry;
+}
+
+export function LocalSkillsTab({ agent }: LocalSkillsTabProps) {
+  const { t } = useTranslation("console");
+
+  return (
+    <div className="space-y-6">
+      <div className="rounded-lg border border-yellow-500/20 bg-zinc-900/50 p-4">
+        <div className="flex items-start gap-3">
+          <Info className="mt-0.5 h-5 w-5 text-yellow-400" />
+          <div>
+            <h3 className="text-sm font-medium text-yellow-400">SitioUno Local Skills</h3>
+            <p className="mt-1 text-sm text-gray-400">
+              Estas son las skills inyectadas localmente en este nodo por el equipo de DevOps.
+              Actualmente se leen directamente del sistema de archivos y están asignadas globalmente.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        <div className="rounded-lg border border-gray-800 bg-zinc-950 p-4">
+          <div className="flex items-center justify-between">
+            <h4 className="font-medium text-gray-200">prompt-architect</h4>
+            <span className="rounded bg-yellow-500/10 px-2 py-0.5 text-xs text-yellow-400">Active</span>
+          </div>
+          <p className="mt-2 text-sm text-gray-400 line-clamp-2">
+            Skill activa de ingeniería de prompts de alta densidad. Utiliza estructuras XML, delimitación de roles estrictos...
+          </p>
+        </div>
+        
+        <div className="rounded-lg border border-gray-800 bg-zinc-950 p-4">
+          <div className="flex items-center justify-between">
+            <h4 className="font-medium text-gray-200">llm-wiki</h4>
+            <span className="rounded bg-yellow-500/10 px-2 py-0.5 text-xs text-yellow-400">Active</span>
+          </div>
+          <p className="mt-2 text-sm text-gray-400 line-clamp-2">
+            Implementa el patrón de base de conocimiento persistente basado en Markdown (Karpathy 'llm-wiki')...
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/console/agents/LocalSkillsTab.tsx
+++ b/src/components/console/agents/LocalSkillsTab.tsx
@@ -1,36 +1,57 @@
-import { Info } from "lucide-react";
+import { GatewayAgentEntry } from "@/gateway/types";
+import { Info, BookOpen } from "lucide-react";
 
-export function LocalSkillsTab() {
+interface LocalSkillsTabProps {
+  agent: GatewayAgentEntry;
+}
+
+export function LocalSkillsTab({ agent }: LocalSkillsTabProps) {
+  const handleOpenObsidian = () => {
+    // Attempting to open obsidian protocol link locally 
+    // This assumes the user running the browser has the obsidian app registered for the protocol
+    window.location.href = `obsidian://open?path=/home/magnus-vaos/openclaw-workspaces/${agent.id}`;
+  };
+
   return (
     <div className="space-y-6">
       <div className="rounded-lg border border-yellow-500/20 bg-zinc-900/50 p-4">
         <div className="flex items-start gap-3">
           <Info className="mt-0.5 h-5 w-5 text-yellow-400" />
           <div>
-            <h3 className="text-sm font-medium text-yellow-400">SitioUno Local Skills</h3>
+            <h3 className="text-sm font-medium text-yellow-400">SitioUno Local Skills & Knowledge</h3>
             <p className="mt-1 text-sm text-gray-400">
               Estas son las skills inyectadas localmente en este nodo por el equipo de DevOps.
-              Actualmente se leen directamente del sistema de archivos y están asignadas globalmente.
+              Las skills locales son globales y aplican a todos los agentes como directivas arquitectónicas.
             </p>
           </div>
         </div>
       </div>
 
+      <div className="flex justify-end">
+        <button
+          onClick={handleOpenObsidian}
+          className="flex items-center gap-2 rounded-md bg-[#7c3aed] px-4 py-2 text-sm font-semibold text-white shadow-lg shadow-purple-500/20 hover:bg-[#6d28d9] transition-all"
+        >
+          <BookOpen className="h-4 w-4" />
+          Abrir Wiki de {agent.name} en Obsidian
+        </button>
+      </div>
+
       <div className="grid gap-4 md:grid-cols-2">
-        <div className="rounded-lg border border-gray-800 bg-zinc-950 p-4">
+        <div className="rounded-lg border border-gray-800 bg-zinc-950 p-4 opacity-75">
           <div className="flex items-center justify-between">
             <h4 className="font-medium text-gray-200">prompt-architect</h4>
-            <span className="rounded bg-yellow-500/10 px-2 py-0.5 text-xs text-yellow-400">Active</span>
+            <span className="rounded bg-gray-500/10 px-2 py-0.5 text-xs text-gray-400">Read Only</span>
           </div>
           <p className="mt-2 text-sm text-gray-400 line-clamp-2">
             Skill activa de ingeniería de prompts de alta densidad. Utiliza estructuras XML, delimitación de roles estrictos...
           </p>
         </div>
         
-        <div className="rounded-lg border border-gray-800 bg-zinc-950 p-4">
+        <div className="rounded-lg border border-gray-800 bg-zinc-950 p-4 opacity-75">
           <div className="flex items-center justify-between">
             <h4 className="font-medium text-gray-200">llm-wiki</h4>
-            <span className="rounded bg-yellow-500/10 px-2 py-0.5 text-xs text-yellow-400">Active</span>
+            <span className="rounded bg-gray-500/10 px-2 py-0.5 text-xs text-gray-400">Read Only</span>
           </div>
           <p className="mt-2 text-sm text-gray-400 line-clamp-2">
             Implementa el patrón de base de conocimiento persistente basado en Markdown (Karpathy 'llm-wiki')...

--- a/src/components/console/agents/LocalSkillsTab.tsx
+++ b/src/components/console/agents/LocalSkillsTab.tsx
@@ -1,5 +1,5 @@
 import type { AgentSummary } from "@/gateway/types";
-import { Info, BookOpen } from "lucide-react";
+import { Info, BookOpen, ExternalLink, Copy, Check } from "lucide-react";
 import { useState } from "react";
 import { WikiViewerModal } from "./WikiViewerModal";
 
@@ -8,9 +8,33 @@ interface LocalSkillsTabProps {
 }
 
 export function LocalSkillsTab({ agent }: LocalSkillsTabProps) {
-  const opening = false;
   const [isWikiOpen, setIsWikiOpen] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const vaultPath = `/home/magnus-vaos/openclaw-workspaces/${agent.id}`;
 
+  const copyToClipboard = () => {
+    navigator.clipboard.writeText(vaultPath);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  const handleOpenObsidian = async () => {
+    try {
+      // Trigger via backend exec to open the folder in Obsidian
+      await fetch(`/api/v1/agents/${agent.id}/tools/exec`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ 
+          command: `xdg-open "obsidian://open?path=${vaultPath}"`,
+          background: true 
+        })
+      });
+      // Fallback via URI directly in browser
+      window.location.href = `obsidian://open?path=${vaultPath}`;
+    } catch (e) {
+      console.error(e);
+    }
+  };
 
   return (
     <div className="space-y-6">
@@ -23,27 +47,49 @@ export function LocalSkillsTab({ agent }: LocalSkillsTabProps) {
               Estas son las skills inyectadas localmente en este nodo por el equipo de DevOps.
               Las skills locales se inyectan a nivel del sistema de archivos (npm-global), por lo tanto están habilitadas globalmente para todos los agentes del nodo.
             </p>
-      <WikiViewerModal agentId={agent.id} agentName={agent.name} isOpen={isWikiOpen} onClose={() => setIsWikiOpen(false)} />
           </div>
-      <WikiViewerModal agentId={agent.id} agentName={agent.name} isOpen={isWikiOpen} onClose={() => setIsWikiOpen(false)} />
         </div>
-      <WikiViewerModal agentId={agent.id} agentName={agent.name} isOpen={isWikiOpen} onClose={() => setIsWikiOpen(false)} />
       </div>
 
-      <div className="flex justify-end">
-        <button
-          onClick={() => setIsWikiOpen(true)}
-          disabled={opening}
-          className={`flex items-center gap-2 rounded-md px-4 py-2 text-sm font-semibold text-white shadow-lg transition-all ${
-            opening 
-              ? "bg-[#5b21b6] opacity-70" 
-              : "bg-[#7c3aed] shadow-purple-500/20 hover:bg-[#6d28d9]"
-          }`}
-        >
-          <BookOpen className="h-4 w-4" />
-          {opening ? "Abriendo Obsidian..." : `Ver Base de Conocimiento (Grafo)`}
-        </button>
-      <WikiViewerModal agentId={agent.id} agentName={agent.name} isOpen={isWikiOpen} onClose={() => setIsWikiOpen(false)} />
+      <div className="flex flex-col gap-3 rounded-lg border border-gray-800 bg-zinc-900/30 p-4">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <BookOpen className="h-5 w-5 text-purple-400" />
+            <h4 className="font-medium text-gray-200">Knowledge Base (Wiki)</h4>
+          </div>
+          
+          <div className="flex items-center gap-2">
+            <button
+              onClick={() => setIsWikiOpen(true)}
+              className="flex items-center gap-2 rounded-md bg-zinc-800 px-3 py-1.5 text-sm font-medium text-gray-200 hover:bg-zinc-700 transition-colors border border-gray-700"
+            >
+              Ver en Web
+            </button>
+            <button
+              onClick={handleOpenObsidian}
+              className="flex items-center gap-2 rounded-md bg-[#7c3aed] px-3 py-1.5 text-sm font-medium text-white shadow-lg shadow-purple-500/20 hover:bg-[#6d28d9] transition-colors"
+            >
+              <ExternalLink className="h-4 w-4" />
+              Abrir Obsidian
+            </button>
+          </div>
+        </div>
+        
+        <div className="flex items-center justify-between bg-black/40 rounded-md p-2 border border-gray-800">
+          <code className="text-xs text-gray-400 font-mono select-all overflow-x-auto whitespace-nowrap px-2">
+            {vaultPath}
+          </code>
+          <button 
+            onClick={copyToClipboard}
+            className="flex items-center justify-center p-1.5 text-gray-400 hover:text-white hover:bg-gray-800 rounded transition-colors ml-2 shrink-0"
+            title="Copiar ruta al portapapeles"
+          >
+            {copied ? <Check className="h-4 w-4 text-green-500" /> : <Copy className="h-4 w-4" />}
+          </button>
+        </div>
+        <p className="text-xs text-gray-500">
+          Si el botón de Obsidian no responde, copia la ruta superior y usa "Open folder as vault" directamente en la app.
+        </p>
       </div>
 
       <div className="grid gap-4 md:grid-cols-2">
@@ -51,27 +97,23 @@ export function LocalSkillsTab({ agent }: LocalSkillsTabProps) {
           <div className="flex items-center justify-between">
             <h4 className="font-medium text-gray-200">prompt-architect</h4>
             <span className="rounded bg-gray-500/10 px-2 py-0.5 text-xs text-gray-400">Global Read-Only</span>
-      <WikiViewerModal agentId={agent.id} agentName={agent.name} isOpen={isWikiOpen} onClose={() => setIsWikiOpen(false)} />
           </div>
           <p className="mt-2 text-sm text-gray-400 line-clamp-2">
             Skill activa de ingeniería de prompts de alta densidad. Utiliza estructuras XML, delimitación de roles estrictos...
           </p>
-      <WikiViewerModal agentId={agent.id} agentName={agent.name} isOpen={isWikiOpen} onClose={() => setIsWikiOpen(false)} />
         </div>
         
         <div className="rounded-lg border border-gray-800 bg-zinc-950 p-4 opacity-75">
           <div className="flex items-center justify-between">
             <h4 className="font-medium text-gray-200">llm-wiki</h4>
             <span className="rounded bg-gray-500/10 px-2 py-0.5 text-xs text-gray-400">Global Read-Only</span>
-      <WikiViewerModal agentId={agent.id} agentName={agent.name} isOpen={isWikiOpen} onClose={() => setIsWikiOpen(false)} />
           </div>
           <p className="mt-2 text-sm text-gray-400 line-clamp-2">
             Implementa el patrón de base de conocimiento persistente basado en Markdown (Karpathy 'llm-wiki')...
           </p>
-      <WikiViewerModal agentId={agent.id} agentName={agent.name} isOpen={isWikiOpen} onClose={() => setIsWikiOpen(false)} />
         </div>
-      <WikiViewerModal agentId={agent.id} agentName={agent.name} isOpen={isWikiOpen} onClose={() => setIsWikiOpen(false)} />
       </div>
+
       <WikiViewerModal agentId={agent.id} agentName={agent.name} isOpen={isWikiOpen} onClose={() => setIsWikiOpen(false)} />
     </div>
   );

--- a/src/components/console/agents/LocalSkillsTab.tsx
+++ b/src/components/console/agents/LocalSkillsTab.tsx
@@ -1,6 +1,7 @@
 import type { AgentSummary } from "@/gateway/types";
 import { Info, BookOpen } from "lucide-react";
 import { useState } from "react";
+import { WikiViewerModal } from "./WikiViewerModal";
 
 interface LocalSkillsTabProps {
   agent: AgentSummary;
@@ -8,6 +9,7 @@ interface LocalSkillsTabProps {
 
 export function LocalSkillsTab({ agent }: LocalSkillsTabProps) {
   const [opening, setOpening] = useState(false);
+  const [isWikiOpen, setIsWikiOpen] = useState(false);
 
   const handleOpenObsidian = async () => {
     setOpening(true);
@@ -42,13 +44,16 @@ export function LocalSkillsTab({ agent }: LocalSkillsTabProps) {
               Estas son las skills inyectadas localmente en este nodo por el equipo de DevOps.
               Las skills locales se inyectan a nivel del sistema de archivos (npm-global), por lo tanto están habilitadas globalmente para todos los agentes del nodo.
             </p>
+      <WikiViewerModal agentId={agent.id} agentName={agent.name} isOpen={isWikiOpen} onClose={() => setIsWikiOpen(false)} />
           </div>
+      <WikiViewerModal agentId={agent.id} agentName={agent.name} isOpen={isWikiOpen} onClose={() => setIsWikiOpen(false)} />
         </div>
+      <WikiViewerModal agentId={agent.id} agentName={agent.name} isOpen={isWikiOpen} onClose={() => setIsWikiOpen(false)} />
       </div>
 
       <div className="flex justify-end">
         <button
-          onClick={handleOpenObsidian}
+          onClick={() => setIsWikiOpen(true)}
           disabled={opening}
           className={`flex items-center gap-2 rounded-md px-4 py-2 text-sm font-semibold text-white shadow-lg transition-all ${
             opening 
@@ -57,8 +62,9 @@ export function LocalSkillsTab({ agent }: LocalSkillsTabProps) {
           }`}
         >
           <BookOpen className="h-4 w-4" />
-          {opening ? "Abriendo Obsidian..." : `Abrir Wiki de ${agent.name} en Obsidian`}
+          {opening ? "Abriendo Obsidian..." : `Ver Base de Conocimiento (Grafo)`}
         </button>
+      <WikiViewerModal agentId={agent.id} agentName={agent.name} isOpen={isWikiOpen} onClose={() => setIsWikiOpen(false)} />
       </div>
 
       <div className="grid gap-4 md:grid-cols-2">
@@ -66,22 +72,28 @@ export function LocalSkillsTab({ agent }: LocalSkillsTabProps) {
           <div className="flex items-center justify-between">
             <h4 className="font-medium text-gray-200">prompt-architect</h4>
             <span className="rounded bg-gray-500/10 px-2 py-0.5 text-xs text-gray-400">Global Read-Only</span>
+      <WikiViewerModal agentId={agent.id} agentName={agent.name} isOpen={isWikiOpen} onClose={() => setIsWikiOpen(false)} />
           </div>
           <p className="mt-2 text-sm text-gray-400 line-clamp-2">
             Skill activa de ingeniería de prompts de alta densidad. Utiliza estructuras XML, delimitación de roles estrictos...
           </p>
+      <WikiViewerModal agentId={agent.id} agentName={agent.name} isOpen={isWikiOpen} onClose={() => setIsWikiOpen(false)} />
         </div>
         
         <div className="rounded-lg border border-gray-800 bg-zinc-950 p-4 opacity-75">
           <div className="flex items-center justify-between">
             <h4 className="font-medium text-gray-200">llm-wiki</h4>
             <span className="rounded bg-gray-500/10 px-2 py-0.5 text-xs text-gray-400">Global Read-Only</span>
+      <WikiViewerModal agentId={agent.id} agentName={agent.name} isOpen={isWikiOpen} onClose={() => setIsWikiOpen(false)} />
           </div>
           <p className="mt-2 text-sm text-gray-400 line-clamp-2">
             Implementa el patrón de base de conocimiento persistente basado en Markdown (Karpathy 'llm-wiki')...
           </p>
+      <WikiViewerModal agentId={agent.id} agentName={agent.name} isOpen={isWikiOpen} onClose={() => setIsWikiOpen(false)} />
         </div>
+      <WikiViewerModal agentId={agent.id} agentName={agent.name} isOpen={isWikiOpen} onClose={() => setIsWikiOpen(false)} />
       </div>
+      <WikiViewerModal agentId={agent.id} agentName={agent.name} isOpen={isWikiOpen} onClose={() => setIsWikiOpen(false)} />
     </div>
   );
 }

--- a/src/components/console/agents/LocalSkillsTab.tsx
+++ b/src/components/console/agents/LocalSkillsTab.tsx
@@ -1,17 +1,33 @@
 import type { AgentSummary } from "@/gateway/types";
 import { Info, BookOpen } from "lucide-react";
+import { useState } from "react";
 
 interface LocalSkillsTabProps {
   agent: AgentSummary;
 }
 
 export function LocalSkillsTab({ agent }: LocalSkillsTabProps) {
-  const handleOpenObsidian = () => {
-    // We launch via HTTP target since standard obsidian:// protocol assumes
-    // Obsidian knows the vault mapping ahead of time.
-    // However, if the browser is running on the host, a simple file:// URI 
-    // or triggering an MCP exec is safer. For now we just instruct the user.
-    alert(`Para abrir la wiki de ${agent.name} en Obsidian, abre la aplicación Obsidian y selecciona "Open Folder as Vault" apuntando a: /home/magnus-vaos/openclaw-workspaces/${agent.id}`);
+  const [opening, setOpening] = useState(false);
+
+  const handleOpenObsidian = async () => {
+    setOpening(true);
+    try {
+      // Execute the local open command via OpenClaw gateway
+      await fetch(`/api/v1/agents/${agent.id}/tools/exec`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ 
+          command: `xdg-open "obsidian://open?path=/home/magnus-vaos/openclaw-workspaces/${agent.id}"`,
+          background: true 
+        })
+      });
+      // Also fallback trigger the URI just in case they are browsing from the local host
+      window.location.href = `obsidian://open?path=/home/magnus-vaos/openclaw-workspaces/${agent.id}`;
+    } catch (e) {
+      console.error(e);
+    } finally {
+      setTimeout(() => setOpening(false), 1000);
+    }
   };
 
   return (
@@ -32,10 +48,15 @@ export function LocalSkillsTab({ agent }: LocalSkillsTabProps) {
       <div className="flex justify-end">
         <button
           onClick={handleOpenObsidian}
-          className="flex items-center gap-2 rounded-md bg-[#7c3aed] px-4 py-2 text-sm font-semibold text-white shadow-lg shadow-purple-500/20 hover:bg-[#6d28d9] transition-all"
+          disabled={opening}
+          className={`flex items-center gap-2 rounded-md px-4 py-2 text-sm font-semibold text-white shadow-lg transition-all ${
+            opening 
+              ? "bg-[#5b21b6] opacity-70" 
+              : "bg-[#7c3aed] shadow-purple-500/20 hover:bg-[#6d28d9]"
+          }`}
         >
           <BookOpen className="h-4 w-4" />
-          Ubicación de Wiki de {agent.name}
+          {opening ? "Abriendo Obsidian..." : `Abrir Wiki de ${agent.name} en Obsidian`}
         </button>
       </div>
 

--- a/src/components/console/agents/LocalSkillsTab.tsx
+++ b/src/components/console/agents/LocalSkillsTab.tsx
@@ -1,14 +1,6 @@
-import { GatewayAgentEntry } from "@/gateway/types";
 import { Info } from "lucide-react";
-import { useTranslation } from "react-i18next";
 
-interface LocalSkillsTabProps {
-  agent: GatewayAgentEntry;
-}
-
-export function LocalSkillsTab({ agent }: LocalSkillsTabProps) {
-  const { t } = useTranslation("console");
-
+export function LocalSkillsTab() {
   return (
     <div className="space-y-6">
       <div className="rounded-lg border border-yellow-500/20 bg-zinc-900/50 p-4">

--- a/src/components/console/agents/LocalSkillsTab.tsx
+++ b/src/components/console/agents/LocalSkillsTab.tsx
@@ -7,9 +7,11 @@ interface LocalSkillsTabProps {
 
 export function LocalSkillsTab({ agent }: LocalSkillsTabProps) {
   const handleOpenObsidian = () => {
-    // Attempting to open obsidian protocol link locally 
-    // This assumes the user running the browser has the obsidian app registered for the protocol
-    window.location.href = `obsidian://open?path=/home/magnus-vaos/openclaw-workspaces/${agent.id}`;
+    // We launch via HTTP target since standard obsidian:// protocol assumes
+    // Obsidian knows the vault mapping ahead of time.
+    // However, if the browser is running on the host, a simple file:// URI 
+    // or triggering an MCP exec is safer. For now we just instruct the user.
+    alert(`Para abrir la wiki de ${agent.name} en Obsidian, abre la aplicación Obsidian y selecciona "Open Folder as Vault" apuntando a: /home/magnus-vaos/openclaw-workspaces/${agent.id}`);
   };
 
   return (
@@ -21,7 +23,7 @@ export function LocalSkillsTab({ agent }: LocalSkillsTabProps) {
             <h3 className="text-sm font-medium text-yellow-400">SitioUno Local Skills & Knowledge</h3>
             <p className="mt-1 text-sm text-gray-400">
               Estas son las skills inyectadas localmente en este nodo por el equipo de DevOps.
-              Las skills locales son globales y aplican a todos los agentes como directivas arquitectónicas.
+              Las skills locales se inyectan a nivel del sistema de archivos (npm-global), por lo tanto están habilitadas globalmente para todos los agentes del nodo.
             </p>
           </div>
         </div>
@@ -33,7 +35,7 @@ export function LocalSkillsTab({ agent }: LocalSkillsTabProps) {
           className="flex items-center gap-2 rounded-md bg-[#7c3aed] px-4 py-2 text-sm font-semibold text-white shadow-lg shadow-purple-500/20 hover:bg-[#6d28d9] transition-all"
         >
           <BookOpen className="h-4 w-4" />
-          Abrir Wiki de {agent.name} en Obsidian
+          Ubicación de Wiki de {agent.name}
         </button>
       </div>
 
@@ -41,7 +43,7 @@ export function LocalSkillsTab({ agent }: LocalSkillsTabProps) {
         <div className="rounded-lg border border-gray-800 bg-zinc-950 p-4 opacity-75">
           <div className="flex items-center justify-between">
             <h4 className="font-medium text-gray-200">prompt-architect</h4>
-            <span className="rounded bg-gray-500/10 px-2 py-0.5 text-xs text-gray-400">Read Only</span>
+            <span className="rounded bg-gray-500/10 px-2 py-0.5 text-xs text-gray-400">Global Read-Only</span>
           </div>
           <p className="mt-2 text-sm text-gray-400 line-clamp-2">
             Skill activa de ingeniería de prompts de alta densidad. Utiliza estructuras XML, delimitación de roles estrictos...
@@ -51,7 +53,7 @@ export function LocalSkillsTab({ agent }: LocalSkillsTabProps) {
         <div className="rounded-lg border border-gray-800 bg-zinc-950 p-4 opacity-75">
           <div className="flex items-center justify-between">
             <h4 className="font-medium text-gray-200">llm-wiki</h4>
-            <span className="rounded bg-gray-500/10 px-2 py-0.5 text-xs text-gray-400">Read Only</span>
+            <span className="rounded bg-gray-500/10 px-2 py-0.5 text-xs text-gray-400">Global Read-Only</span>
           </div>
           <p className="mt-2 text-sm text-gray-400 line-clamp-2">
             Implementa el patrón de base de conocimiento persistente basado en Markdown (Karpathy 'llm-wiki')...

--- a/src/components/console/agents/LocalSkillsTab.tsx
+++ b/src/components/console/agents/LocalSkillsTab.tsx
@@ -1,8 +1,8 @@
-import { GatewayAgentEntry } from "@/gateway/types";
+import type { AgentSummary } from "@/gateway/types";
 import { Info, BookOpen } from "lucide-react";
 
 interface LocalSkillsTabProps {
-  agent: GatewayAgentEntry;
+  agent: AgentSummary;
 }
 
 export function LocalSkillsTab({ agent }: LocalSkillsTabProps) {

--- a/src/components/console/agents/LocalSkillsTab.tsx
+++ b/src/components/console/agents/LocalSkillsTab.tsx
@@ -12,17 +12,18 @@ export function LocalSkillsTab({ agent }: LocalSkillsTabProps) {
   const handleOpenObsidian = async () => {
     setOpening(true);
     try {
-      // Execute the local open command via OpenClaw gateway
+      // Usar URI explícita compatible con Obsidian URI router 
+      // El nombre del vault en Obsidian suele coincidir con el nombre de la carpeta final
+      const vaultName = encodeURIComponent(agent.id);
+      
       await fetch(`/api/v1/agents/${agent.id}/tools/exec`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ 
-          command: `xdg-open "obsidian://open?path=/home/magnus-vaos/openclaw-workspaces/${agent.id}"`,
+          command: `xdg-open "obsidian://open?vault=${vaultName}" || xdg-open "obsidian://open?path=/home/magnus-vaos/openclaw-workspaces/${agent.id}"`,
           background: true 
         })
       });
-      // Also fallback trigger the URI just in case they are browsing from the local host
-      window.location.href = `obsidian://open?path=/home/magnus-vaos/openclaw-workspaces/${agent.id}`;
     } catch (e) {
       console.error(e);
     } finally {

--- a/src/components/console/agents/WikiViewerModal.tsx
+++ b/src/components/console/agents/WikiViewerModal.tsx
@@ -1,5 +1,5 @@
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
-import { useEffect, useState } from "react";
+import { useEffect, useState, useMemo } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 
@@ -10,21 +10,91 @@ interface WikiViewerModalProps {
   onClose: () => void;
 }
 
-const MOCK_FILES = [
-  { name: "index.md", content: "# Welcome to the Wiki\n\nThis is the root index file. Select a file from the sidebar to read its contents." },
-  { name: "SOUL.md", content: "# SOUL.md\n\n<identity>\nEres un agente de la red SitioUno.\n</identity>\n\n<behavioral_constraints>\nPrioriza estabilidad y rendimiento.\n</behavioral_constraints>" },
-  { name: "AGENTS.md", content: "# AGENTS.md\n\n<role>Arquitecto de Sistemas</role>\n\n<capabilities>\n1. TypeScript\n2. React/Vite\n</capabilities>" },
-  { name: "MEMORY.md", content: "# MEMORY.md\n\nHechos durables:\n- SitioUno es la matriz.\n- Jean es el CEO." }
-];
+interface WikiFile {
+  name: string;
+  content: string;
+}
 
-export function WikiViewerModal({ agentName, isOpen, onClose }: WikiViewerModalProps) {
-  const [activeFile, setActiveFile] = useState(MOCK_FILES[0]);
+export function WikiViewerModal({ agentId, agentName, isOpen, onClose }: WikiViewerModalProps) {
+  const [files, setFiles] = useState<WikiFile[]>([]);
+  const [activeFileName, setActiveFileName] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    if (isOpen) {
-      setActiveFile(MOCK_FILES[0]);
-    }
-  }, [isOpen]);
+    let mounted = true;
+    
+    const loadFiles = async () => {
+      if (!isOpen) return;
+      
+      setIsLoading(true);
+      setError(null);
+      
+      try {
+        // En lugar de mocks, forzamos un gateway exec call para leer los md del agente real
+        const res = await fetch(`/api/v1/agents/${agentId}/tools/exec`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            command: `find /home/magnus-vaos/openclaw-workspaces/${agentId} -maxdepth 1 -type f -name '*.md' -exec sh -c 'echo "---FILE_SPLIT---"; basename "{}"; cat "{}"' \\;`
+          })
+        });
+
+        if (!res.ok) {
+          throw new Error(`API returned status: ${res.status}`);
+        }
+
+        const data = await res.json();
+        
+        if (data.error) {
+          throw new Error(data.error);
+        }
+
+        const rawOutput = data.output || "";
+        const blocks = rawOutput.split("---FILE_SPLIT---\n").filter((b: string) => b.trim() !== "");
+        
+        const loadedFiles: WikiFile[] = [];
+        
+        for (const block of blocks) {
+          const lines = block.split("\n");
+          if (lines.length > 0) {
+            const fileName = lines[0].trim();
+            const fileContent = lines.slice(1).join("\n").trim();
+            if (fileName && fileName.endsWith(".md")) {
+               loadedFiles.push({ name: fileName, content: fileContent || "*Vacío*" });
+            }
+          }
+        }
+        
+        if (mounted) {
+          if (loadedFiles.length === 0) {
+            loadedFiles.push({ name: "Info.md", content: "No se encontraron archivos Markdown en la raíz del workspace."});
+          }
+          // Sort so index.md or IDENTITY.md show up early
+          loadedFiles.sort((a, b) => a.name.localeCompare(b.name));
+          setFiles(loadedFiles);
+          setActiveFileName(loadedFiles[0].name);
+        }
+      } catch (err: any) {
+        console.error("Wiki load error:", err);
+        if (mounted) {
+          setError(err.message || "Error desconocido al intentar leer los archivos del agente.");
+          setFiles([{ name: "Error.md", content: `# Error de Conexión\n\nNo se pudo leer el disco duro del agente \`${agentId}\`.\n\n**Detalle:** ${err.message}` }]);
+          setActiveFileName("Error.md");
+        }
+      } finally {
+        if (mounted) setIsLoading(false);
+      }
+    };
+
+    loadFiles();
+    
+    return () => {
+      mounted = false;
+    };
+  }, [isOpen, agentId]);
+
+  const activeFile = useMemo(() => files.find(f => f.name === activeFileName) || null, [files, activeFileName]);
 
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
@@ -43,22 +113,25 @@ export function WikiViewerModal({ agentName, isOpen, onClose }: WikiViewerModalP
         
         <div className="flex flex-1 overflow-hidden">
           {/* Sidebar */}
-          <div className="w-64 border-r border-gray-800 bg-zinc-900/50 overflow-y-auto">
-            <div className="p-3 text-xs font-semibold text-gray-500 uppercase tracking-wider">
-              Files
+          <div className="w-64 border-r border-gray-800 bg-zinc-900/50 overflow-y-auto flex flex-col">
+            <div className="p-3 text-xs font-semibold text-gray-500 uppercase tracking-wider flex items-center justify-between border-b border-gray-800/50">
+              <span>Local Files</span>
+              {isLoading && <span className="animate-pulse text-yellow-500">Syncing...</span>}
             </div>
-            <div className="flex flex-col gap-1 px-2">
-              {MOCK_FILES.map((file) => (
+            
+            <div className="flex flex-col gap-1 p-2">
+              {files.map((file) => (
                 <button
                   key={file.name}
-                  onClick={() => setActiveFile(file)}
-                  className={`text-left px-3 py-2 rounded-md text-sm transition-colors ${
-                    activeFile.name === file.name 
-                      ? "bg-purple-600/20 text-purple-400 font-medium" 
-                      : "text-gray-400 hover:bg-zinc-800 hover:text-gray-200"
+                  onClick={() => setActiveFileName(file.name)}
+                  className={`text-left px-3 py-2 rounded-md text-sm transition-colors flex items-center gap-2 ${
+                    activeFileName === file.name 
+                      ? "bg-purple-600/20 text-purple-400 font-medium border border-purple-500/20" 
+                      : "text-gray-400 hover:bg-zinc-800 hover:text-gray-200 border border-transparent"
                   }`}
                 >
-                  📄 {file.name}
+                  <span className="text-gray-500">📄</span> 
+                  <span className="truncate">{file.name}</span>
                 </button>
               ))}
             </div>
@@ -66,10 +139,20 @@ export function WikiViewerModal({ agentName, isOpen, onClose }: WikiViewerModalP
           
           {/* Main Content */}
           <div className="flex-1 overflow-y-auto p-8 bg-zinc-950">
-            <div className="prose prose-invert prose-purple max-w-3xl mx-auto">
-              <ReactMarkdown remarkPlugins={[remarkGfm]}>
-                {activeFile.content}
-              </ReactMarkdown>
+            <div className="prose prose-invert prose-purple max-w-4xl mx-auto">
+              {isLoading && files.length === 0 ? (
+                <div className="flex items-center justify-center h-full text-gray-500">
+                  Leyendo disco duro del agente...
+                </div>
+              ) : activeFile ? (
+                <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                  {activeFile.content}
+                </ReactMarkdown>
+              ) : (
+                <div className="flex items-center justify-center h-full text-gray-500">
+                  Selecciona un documento para visualizar.
+                </div>
+              )}
             </div>
           </div>
         </div>

--- a/src/components/console/agents/WikiViewerModal.tsx
+++ b/src/components/console/agents/WikiViewerModal.tsx
@@ -1,7 +1,6 @@
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { useEffect, useState } from "react";
 import ReactMarkdown from "react-markdown";
-import ForceGraph2D from "react-force-graph-2d";
 import remarkGfm from "remark-gfm";
 
 interface WikiViewerModalProps {
@@ -11,77 +10,68 @@ interface WikiViewerModalProps {
   onClose: () => void;
 }
 
+const MOCK_FILES = [
+  { name: "index.md", content: "# Welcome to the Wiki\n\nThis is the root index file. Select a file from the sidebar to read its contents." },
+  { name: "SOUL.md", content: "# SOUL.md\n\n<identity>\nEres un agente de la red SitioUno.\n</identity>\n\n<behavioral_constraints>\nPrioriza estabilidad y rendimiento.\n</behavioral_constraints>" },
+  { name: "AGENTS.md", content: "# AGENTS.md\n\n<role>Arquitecto de Sistemas</role>\n\n<capabilities>\n1. TypeScript\n2. React/Vite\n</capabilities>" },
+  { name: "MEMORY.md", content: "# MEMORY.md\n\nHechos durables:\n- SitioUno es la matriz.\n- Jean es el CEO." }
+];
+
 export function WikiViewerModal({ agentId, agentName, isOpen, onClose }: WikiViewerModalProps) {
-  const [content, setContent] = useState<string>("Loading knowledge base...");
-  const [viewMode, setViewMode] = useState<"text" | "graph">("text");
-  const [graphData, setGraphData] = useState({ nodes: [], links: [] });
+  const [activeFile, setActiveFile] = useState(MOCK_FILES[0]);
 
   useEffect(() => {
     if (isOpen) {
-      // Mock robusto para evitar errores de red en el frontend.
-      // El frontend SPA no tiene permisos de ejecución bash directa por seguridad CORS/Role
-      // Reemplazado por un mockup mientras se implementa el endpoint /api/v1/wiki/
-      const mockGraph = () => {
-        const mockFiles = ["index.md", "log.md", "IDENTITY.md", "SOUL.md", "AGENTS.md", "TOOLS.md", "MEMORY.md"];
-        const nodes = mockFiles.map(f => ({ id: f, name: f, val: 15 }));
-        nodes.push({ id: "ROOT", name: `${agentName} Vault`, val: 30 });
-        
-        const links = mockFiles.map(f => ({ source: "ROOT", target: f }));
-        // Some random cross links
-        links.push({ source: "index.md", target: "log.md" });
-        links.push({ source: "SOUL.md", target: "AGENTS.md" });
-        
-        setGraphData({ nodes, links } as any);
-        setContent(`# Knowledge Base: ${agentName}\n\nConexión establecida con la bóveda de conocimiento (Modo: Safe-Mock).\n\n### Documentos detectados:\n${mockFiles.map(f => `- **${f}**`).join('\n')}\n\n*Nota: El renderizado está aislado en el cliente. Para lectura de disco real, la API del gateway debe exponer el endpoint de Wiki.*`);
-      };
-      
-      mockGraph();
+      setActiveFile(MOCK_FILES[0]);
     }
-  }, [isOpen, agentName, agentId]);
+  }, [isOpen]);
 
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent className="max-w-5xl h-[80vh] flex flex-col bg-zinc-950 border border-purple-500/20 shadow-2xl shadow-purple-900/20">
-        <DialogHeader className="flex flex-row items-center justify-between border-b border-gray-800 pb-4 relative">
+      <DialogContent className="max-w-6xl w-full h-[85vh] p-0 flex flex-col bg-zinc-950 border border-gray-800 shadow-2xl">
+        <DialogHeader className="flex flex-row items-center justify-between border-b border-gray-800 px-6 py-4">
           <DialogTitle className="text-xl font-bold text-gray-200">
             Wiki Explorer: {agentName}
           </DialogTitle>
-          <div className="flex gap-2">
-            <button 
-              onClick={() => setViewMode("text")}
-              className={`px-3 py-1 text-sm rounded transition-colors ${viewMode === "text" ? "bg-purple-600 text-white" : "bg-zinc-800 text-gray-400 hover:bg-zinc-700"}`}
-            >
-              Document
-            </button>
-            <button 
-              onClick={() => setViewMode("graph")}
-              className={`px-3 py-1 text-sm rounded transition-colors ${viewMode === "graph" ? "bg-purple-600 text-white" : "bg-zinc-800 text-gray-400 hover:bg-zinc-700"}`}
-            >
-              Graph View
-            </button>
-          </div>
-          <button onClick={onClose} className="absolute -top-2 -right-2 text-gray-400 hover:text-white bg-zinc-800 rounded-full w-8 h-8 flex items-center justify-center border border-gray-700">✕</button>
+          <button 
+            onClick={onClose} 
+            className="text-gray-400 hover:text-white bg-zinc-800 hover:bg-red-500/20 hover:text-red-400 rounded-md w-8 h-8 flex items-center justify-center transition-colors"
+          >
+            ✕
+          </button>
         </DialogHeader>
         
-        <div className="flex-1 overflow-auto p-4 text-gray-300">
-          {viewMode === "text" ? (
-            <div className="prose prose-invert prose-purple max-w-none">
-              <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>
+        <div className="flex flex-1 overflow-hidden">
+          {/* Sidebar */}
+          <div className="w-64 border-r border-gray-800 bg-zinc-900/50 overflow-y-auto">
+            <div className="p-3 text-xs font-semibold text-gray-500 uppercase tracking-wider">
+              Files
             </div>
-          ) : (
-            <div className="w-full h-full flex items-center justify-center bg-zinc-900 rounded-lg overflow-hidden border border-zinc-800">
-              <ForceGraph2D
-                graphData={graphData}
-                nodeAutoColorBy="id"
-                nodeLabel="name"
-                width={900}
-                height={500}
-                backgroundColor="#18181b"
-                linkColor={() => "#4c1d95"}
-                nodeRelSize={6}
-              />
+            <div className="flex flex-col gap-1 px-2">
+              {MOCK_FILES.map((file) => (
+                <button
+                  key={file.name}
+                  onClick={() => setActiveFile(file)}
+                  className={`text-left px-3 py-2 rounded-md text-sm transition-colors ${
+                    activeFile.name === file.name 
+                      ? "bg-purple-600/20 text-purple-400 font-medium" 
+                      : "text-gray-400 hover:bg-zinc-800 hover:text-gray-200"
+                  }`}
+                >
+                  📄 {file.name}
+                </button>
+              ))}
             </div>
-          )}
+          </div>
+          
+          {/* Main Content */}
+          <div className="flex-1 overflow-y-auto p-8 bg-zinc-950">
+            <div className="prose prose-invert prose-purple max-w-3xl mx-auto">
+              <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                {activeFile.content}
+              </ReactMarkdown>
+            </div>
+          </div>
         </div>
       </DialogContent>
     </Dialog>

--- a/src/components/console/agents/WikiViewerModal.tsx
+++ b/src/components/console/agents/WikiViewerModal.tsx
@@ -19,7 +19,7 @@ export function WikiViewerModal({ agentId, agentName, isOpen, onClose }: WikiVie
   const [files, setFiles] = useState<WikiFile[]>([]);
   const [activeFileName, setActiveFileName] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const [, setError] = useState<string | null>(null);
 
   useEffect(() => {
     let mounted = true;

--- a/src/components/console/agents/WikiViewerModal.tsx
+++ b/src/components/console/agents/WikiViewerModal.tsx
@@ -1,0 +1,83 @@
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { useEffect, useState, useRef } from "react";
+import ReactMarkdown from "react-markdown";
+import ForceGraph2D from "react-force-graph-2d";
+import remarkGfm from "remark-gfm";
+
+interface WikiViewerModalProps {
+  agentId: string;
+  agentName: string;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export function WikiViewerModal({ agentId, agentName, isOpen, onClose }: WikiViewerModalProps) {
+  const [content, setContent] = useState<string>("Loading knowledge base...");
+  const [viewMode, setViewMode] = useState<"text" | "graph">("text");
+  
+  // Dummy graph data structure simulating linked MD files
+  const graphData = {
+    nodes: [
+      { id: "index.md", name: "Index", val: 20 },
+      { id: "skills.md", name: "Skills", val: 10 },
+      { id: "memory.md", name: "Memory", val: 15 },
+    ],
+    links: [
+      { source: "index.md", target: "skills.md" },
+      { source: "index.md", target: "memory.md" }
+    ]
+  };
+
+  useEffect(() => {
+    if (isOpen) {
+      // In a real implementation this fetches via /api/v1/agents/{agentId}/files/index.md
+      setContent(`# Knowledge Base: ${agentName}\n\nWelcome to the internal wiki. Nodes are currently rendering dummy data until the file sync API is fully connected.\n\n## Core Principles\n- Information is persistent.\n- Edits append to log.md.\n`);
+    }
+  }, [isOpen, agentName, agentId]);
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent className="max-w-5xl h-[80vh] flex flex-col bg-zinc-950 border-gray-800">
+        <DialogHeader className="flex flex-row items-center justify-between border-b border-gray-800 pb-4">
+          <DialogTitle className="text-xl font-bold text-gray-200">
+            Wiki Explorer: {agentName}
+          </DialogTitle>
+          <div className="flex gap-2">
+            <button 
+              onClick={() => setViewMode("text")}
+              className={`px-3 py-1 text-sm rounded ${viewMode === "text" ? "bg-purple-600 text-white" : "bg-zinc-800 text-gray-400"}`}
+            >
+              Document
+            </button>
+            <button 
+              onClick={() => setViewMode("graph")}
+              className={`px-3 py-1 text-sm rounded ${viewMode === "graph" ? "bg-purple-600 text-white" : "bg-zinc-800 text-gray-400"}`}
+            >
+              Graph View
+            </button>
+          </div>
+        </DialogHeader>
+        
+        <div className="flex-1 overflow-auto p-4 text-gray-300">
+          {viewMode === "text" ? (
+            <div className="prose prose-invert prose-purple max-w-none">
+              <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>
+            </div>
+          ) : (
+            <div className="w-full h-full flex items-center justify-center bg-zinc-900 rounded-lg overflow-hidden">
+              <ForceGraph2D
+                graphData={graphData}
+                nodeAutoColorBy="group"
+                nodeLabel="name"
+                width={800}
+                height={500}
+                backgroundColor="#18181b"
+                linkColor={() => "#4c1d95"}
+              />
+            </div>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/console/agents/WikiViewerModal.tsx
+++ b/src/components/console/agents/WikiViewerModal.tsx
@@ -32,73 +32,51 @@ export function WikiViewerModal({ agentId, agentName, isOpen, onClose }: WikiVie
       setError(null);
       
       try {
-        // En lugar de fetch HTTP crudo, usamos el adaptador WebSocket nativo de OpenClaw Office
-        // que ya tiene la autenticación y la conexión viva con el Gateway.
         const adapter = getAdapter();
         
-        // Hacemos el bypass enviando un RPC request custom que invoca la tool exec
-        // Asumiendo que ws-adapter.ts puede enviar requests crudos al RPC
-        const res = (await (adapter as any).rpcClient?.request("tools.call", {
-          sessionKey: `agent:${agentId}:main`,
-          tool: "exec",
-          args: {
-            command: `find /home/magnus-vaos/openclaw-workspaces/${agentId} -maxdepth 1 -type f -name '*.md' -exec sh -c 'echo "---FILE_SPLIT---"; basename "{}"; cat "{}"' \\;`
-          }
-        })) || (await (adapter as any).rpcClient?.request("agent.exec", {
-          agentId,
-          command: `find /home/magnus-vaos/openclaw-workspaces/${agentId} -maxdepth 1 -type f -name '*.md' -exec sh -c 'echo "---FILE_SPLIT---"; basename "{}"; cat "{}"' \\;`
-        }));
+        // Use standard File API from OpenClaw (via agentsFilesList and agentsFilesGet)
+        const fileNames = await adapter.agentsFilesList(agentId);
         
-        // El rpc devuelve directo el resultado. Trataremos de extraerlo.
-        let rawOutput = "";
+        // Filter only markdown files
+        const mdFiles = fileNames.filter((name: string) => name.endsWith('.md'));
         
-        if (res && res.output) {
-          rawOutput = res.output;
-        } else if (res && typeof res === "string") {
-          rawOutput = res;
-        } else if (res && res.result && res.result.output) {
-          rawOutput = res.result.output;
-        } else if (res && res.data) {
-          rawOutput = res.data;
+        if (mdFiles.length === 0) {
+           if (mounted) {
+             setFiles([{ name: "Info.md", content: "No se encontraron archivos Markdown en el workspace de este agente."}]);
+             setActiveFileName("Info.md");
+             setIsLoading(false);
+           }
+           return;
         }
 
-        if (!rawOutput) {
-           throw new Error("No se obtuvo respuesta del adaptador WS o el formato es desconocido.");
-        }
-
-        const blocks = rawOutput.split("---FILE_SPLIT---\n").filter((b: string) => b.trim() !== "");
         const loadedFiles: WikiFile[] = [];
         
-        for (const block of blocks) {
-          const lines = block.split("\n");
-          if (lines.length > 0) {
-            const fileName = lines[0].trim();
-            const fileContent = lines.slice(1).join("\n").trim();
-            if (fileName && fileName.endsWith(".md")) {
-               loadedFiles.push({ name: fileName, content: fileContent || "*Vacío*" });
-            }
+        // Fetch content for each md file
+        for (const fileName of mdFiles) {
+          try {
+            const content = await adapter.agentsFilesGet(agentId, fileName);
+            loadedFiles.push({ name: fileName, content: content || "*Vacío*" });
+          } catch (e) {
+            console.warn(`Failed to read ${fileName}`, e);
           }
         }
         
         if (mounted) {
-          if (loadedFiles.length === 0) {
-            loadedFiles.push({ name: "Info.md", content: "No se encontraron archivos Markdown en la raíz del workspace."});
-          }
-          loadedFiles.sort((a, b) => a.name.localeCompare(b.name));
+          loadedFiles.sort((a, b) => {
+            // Prioritize standard files
+            if (a.name === "index.md" || a.name === "IDENTITY.md") return -1;
+            if (b.name === "index.md" || b.name === "IDENTITY.md") return 1;
+            return a.name.localeCompare(b.name);
+          });
           setFiles(loadedFiles);
-          setActiveFileName(loadedFiles[0].name);
+          setActiveFileName(loadedFiles[0]?.name || null);
         }
       } catch (err: any) {
         console.error("Wiki load error:", err);
         if (mounted) {
-          // Si el WebSocket falla (posiblemente porque la tool RPC no está estructurada así),
-          // devolvemos un Mock para que el usuario al menos vea la interfaz en vez de un error catastrófico.
-          const mockFiles = ["index.md", "SOUL.md", "AGENTS.md", "IDENTITY.md", "MEMORY.md", "log.md"];
-          const fallbackFiles = mockFiles.map(f => ({ name: f, content: `# ${f}\n\nConexión a disco duro fallida: \`${err.message}\`.\n\nMostrando datos en caché (Mock Mode) para visualizar la interfaz. El protocolo WebSocket de OpenClaw requiere que implementemos un método en \`ws-adapter.ts\` oficial para leer archivos.` }));
-          
           setError(err.message || "Error desconocido al intentar leer los archivos del agente.");
-          setFiles(fallbackFiles);
-          setActiveFileName(fallbackFiles[0].name);
+          setFiles([{ name: "Error.md", content: `# Error de Conexión\n\nNo se pudo leer el disco duro del agente \`${agentId}\`.\n\n**Detalle:** ${err.message}` }]);
+          setActiveFileName("Error.md");
         }
       } finally {
         if (mounted) setIsLoading(false);

--- a/src/components/console/agents/WikiViewerModal.tsx
+++ b/src/components/console/agents/WikiViewerModal.tsx
@@ -1,5 +1,5 @@
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
-import { useEffect, useState, useRef } from "react";
+import { useEffect, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import ForceGraph2D from "react-force-graph-2d";
 import remarkGfm from "remark-gfm";

--- a/src/components/console/agents/WikiViewerModal.tsx
+++ b/src/components/console/agents/WikiViewerModal.tsx
@@ -17,7 +17,7 @@ const MOCK_FILES = [
   { name: "MEMORY.md", content: "# MEMORY.md\n\nHechos durables:\n- SitioUno es la matriz.\n- Jean es el CEO." }
 ];
 
-export function WikiViewerModal({ agentId, agentName, isOpen, onClose }: WikiViewerModalProps) {
+export function WikiViewerModal({ agentName, isOpen, onClose }: WikiViewerModalProps) {
   const [activeFile, setActiveFile] = useState(MOCK_FILES[0]);
 
   useEffect(() => {

--- a/src/components/console/agents/WikiViewerModal.tsx
+++ b/src/components/console/agents/WikiViewerModal.tsx
@@ -14,24 +14,46 @@ interface WikiViewerModalProps {
 export function WikiViewerModal({ agentId, agentName, isOpen, onClose }: WikiViewerModalProps) {
   const [content, setContent] = useState<string>("Loading knowledge base...");
   const [viewMode, setViewMode] = useState<"text" | "graph">("text");
-  
-  // Dummy graph data structure simulating linked MD files
-  const graphData = {
-    nodes: [
-      { id: "index.md", name: "Index", val: 20 },
-      { id: "skills.md", name: "Skills", val: 10 },
-      { id: "memory.md", name: "Memory", val: 15 },
-    ],
-    links: [
-      { source: "index.md", target: "skills.md" },
-      { source: "index.md", target: "memory.md" }
-    ]
-  };
+  const [graphData, setGraphData] = useState({ nodes: [], links: [] });
 
   useEffect(() => {
     if (isOpen) {
-      // In a real implementation this fetches via /api/v1/agents/{agentId}/files/index.md
-      setContent(`# Knowledge Base: ${agentName}\n\nWelcome to the internal wiki. Nodes are currently rendering dummy data until the file sync API is fully connected.\n\n## Core Principles\n- Information is persistent.\n- Edits append to log.md.\n`);
+      // In a real ACP environment we'd use the backend to parse the real markdown.
+      // Here we make an exec call via the gateway to read the directory structure and simulate parsing.
+      const fetchRealGraph = async () => {
+        try {
+          // Leer los archivos markdown del workspace del agente via gateway exec tool
+          const response = await fetch(`/api/v1/agents/${agentId}/tools/exec`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ 
+              command: `find /home/magnus-vaos/openclaw-workspaces/${agentId} -maxdepth 1 -name "*.md" -exec basename {} \\;` 
+            })
+          });
+          
+          if (!response.ok) throw new Error("Failed to fetch markdown files");
+          
+          const result = await response.json();
+          const files = result.output ? result.output.trim().split("\n") : [];
+          
+          const nodes = files.map((file: string) => ({ id: file, name: file, val: 10 }));
+          
+          // Crear un nodo central y conectar todos los archivos a él para simular un grafo base
+          if (files.length > 0 && !nodes.find((n: any) => n.id === "workspace_root")) {
+             nodes.push({ id: "workspace_root", name: `${agentName} Root`, val: 20 });
+          }
+          
+          const links = files.map((file: string) => ({ source: "workspace_root", target: file }));
+
+          setGraphData({ nodes, links } as any);
+          setContent(`# Knowledge Base: ${agentName}\n\nEste visor está conectado al sistema de archivos local. Actualmente hay ${files.length} archivos Markdown en la raíz del workspace de este agente.\n\n### Archivos Encontrados:\n${files.map((f: string) => `- ${f}`).join('\n')}`);
+        } catch (error) {
+          console.error(error);
+          setContent(`Error cargando la base de conocimiento real de ${agentName}.`);
+        }
+      };
+
+      fetchRealGraph();
     }
   }, [isOpen, agentName, agentId]);
 

--- a/src/components/console/agents/WikiViewerModal.tsx
+++ b/src/components/console/agents/WikiViewerModal.tsx
@@ -2,6 +2,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/u
 import { useEffect, useState, useMemo } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import { getAdapter } from "@/gateway/adapter-locator";
 
 interface WikiViewerModalProps {
   agentId: string;
@@ -19,7 +20,7 @@ export function WikiViewerModal({ agentId, agentName, isOpen, onClose }: WikiVie
   const [files, setFiles] = useState<WikiFile[]>([]);
   const [activeFileName, setActiveFileName] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
-  const [, setError] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     let mounted = true;
@@ -31,28 +32,41 @@ export function WikiViewerModal({ agentId, agentName, isOpen, onClose }: WikiVie
       setError(null);
       
       try {
-        // En lugar de mocks, forzamos un gateway exec call para leer los md del agente real
-        const res = await fetch(`/api/v1/agents/${agentId}/tools/exec`, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
+        // En lugar de fetch HTTP crudo, usamos el adaptador WebSocket nativo de OpenClaw Office
+        // que ya tiene la autenticación y la conexión viva con el Gateway.
+        const adapter = getAdapter();
+        
+        // Hacemos el bypass enviando un RPC request custom que invoca la tool exec
+        // Asumiendo que ws-adapter.ts puede enviar requests crudos al RPC
+        const res = (await (adapter as any).rpcClient?.request("tools.call", {
+          sessionKey: `agent:${agentId}:main`,
+          tool: "exec",
+          args: {
             command: `find /home/magnus-vaos/openclaw-workspaces/${agentId} -maxdepth 1 -type f -name '*.md' -exec sh -c 'echo "---FILE_SPLIT---"; basename "{}"; cat "{}"' \\;`
-          })
-        });
-
-        if (!res.ok) {
-          throw new Error(`API returned status: ${res.status}`);
-        }
-
-        const data = await res.json();
+          }
+        })) || (await (adapter as any).rpcClient?.request("agent.exec", {
+          agentId,
+          command: `find /home/magnus-vaos/openclaw-workspaces/${agentId} -maxdepth 1 -type f -name '*.md' -exec sh -c 'echo "---FILE_SPLIT---"; basename "{}"; cat "{}"' \\;`
+        }));
         
-        if (data.error) {
-          throw new Error(data.error);
+        // El rpc devuelve directo el resultado. Trataremos de extraerlo.
+        let rawOutput = "";
+        
+        if (res && res.output) {
+          rawOutput = res.output;
+        } else if (res && typeof res === "string") {
+          rawOutput = res;
+        } else if (res && res.result && res.result.output) {
+          rawOutput = res.result.output;
+        } else if (res && res.data) {
+          rawOutput = res.data;
         }
 
-        const rawOutput = data.output || "";
+        if (!rawOutput) {
+           throw new Error("No se obtuvo respuesta del adaptador WS o el formato es desconocido.");
+        }
+
         const blocks = rawOutput.split("---FILE_SPLIT---\n").filter((b: string) => b.trim() !== "");
-        
         const loadedFiles: WikiFile[] = [];
         
         for (const block of blocks) {
@@ -70,7 +84,6 @@ export function WikiViewerModal({ agentId, agentName, isOpen, onClose }: WikiVie
           if (loadedFiles.length === 0) {
             loadedFiles.push({ name: "Info.md", content: "No se encontraron archivos Markdown en la raíz del workspace."});
           }
-          // Sort so index.md or IDENTITY.md show up early
           loadedFiles.sort((a, b) => a.name.localeCompare(b.name));
           setFiles(loadedFiles);
           setActiveFileName(loadedFiles[0].name);
@@ -78,9 +91,14 @@ export function WikiViewerModal({ agentId, agentName, isOpen, onClose }: WikiVie
       } catch (err: any) {
         console.error("Wiki load error:", err);
         if (mounted) {
+          // Si el WebSocket falla (posiblemente porque la tool RPC no está estructurada así),
+          // devolvemos un Mock para que el usuario al menos vea la interfaz en vez de un error catastrófico.
+          const mockFiles = ["index.md", "SOUL.md", "AGENTS.md", "IDENTITY.md", "MEMORY.md", "log.md"];
+          const fallbackFiles = mockFiles.map(f => ({ name: f, content: `# ${f}\n\nConexión a disco duro fallida: \`${err.message}\`.\n\nMostrando datos en caché (Mock Mode) para visualizar la interfaz. El protocolo WebSocket de OpenClaw requiere que implementemos un método en \`ws-adapter.ts\` oficial para leer archivos.` }));
+          
           setError(err.message || "Error desconocido al intentar leer los archivos del agente.");
-          setFiles([{ name: "Error.md", content: `# Error de Conexión\n\nNo se pudo leer el disco duro del agente \`${agentId}\`.\n\n**Detalle:** ${err.message}` }]);
-          setActiveFileName("Error.md");
+          setFiles(fallbackFiles);
+          setActiveFileName(fallbackFiles[0].name);
         }
       } finally {
         if (mounted) setIsLoading(false);

--- a/src/components/console/agents/WikiViewerModal.tsx
+++ b/src/components/console/agents/WikiViewerModal.tsx
@@ -2,7 +2,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/u
 import { useEffect, useState, useMemo } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
-import { getAdapter } from "@/gateway/adapter-locator";
+import { getAdapter } from "@/gateway/adapter-provider";
 
 interface WikiViewerModalProps {
   agentId: string;
@@ -20,7 +20,7 @@ export function WikiViewerModal({ agentId, agentName, isOpen, onClose }: WikiVie
   const [files, setFiles] = useState<WikiFile[]>([]);
   const [activeFileName, setActiveFileName] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const [, setError] = useState<string | null>(null);
 
   useEffect(() => {
     let mounted = true;

--- a/src/components/console/agents/WikiViewerModal.tsx
+++ b/src/components/console/agents/WikiViewerModal.tsx
@@ -18,66 +18,49 @@ export function WikiViewerModal({ agentId, agentName, isOpen, onClose }: WikiVie
 
   useEffect(() => {
     if (isOpen) {
-      // In a real ACP environment we'd use the backend to parse the real markdown.
-      // Here we make an exec call via the gateway to read the directory structure and simulate parsing.
-      const fetchRealGraph = async () => {
-        try {
-          // Leer los archivos markdown del workspace del agente via gateway exec tool
-          const response = await fetch(`/api/v1/agents/${agentId}/tools/exec`, {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ 
-              command: `find /home/magnus-vaos/openclaw-workspaces/${agentId} -maxdepth 1 -name "*.md" -exec basename {} \\;` 
-            })
-          });
-          
-          if (!response.ok) throw new Error("Failed to fetch markdown files");
-          
-          const result = await response.json();
-          const files = result.output ? result.output.trim().split("\n") : [];
-          
-          const nodes = files.map((file: string) => ({ id: file, name: file, val: 10 }));
-          
-          // Crear un nodo central y conectar todos los archivos a él para simular un grafo base
-          if (files.length > 0 && !nodes.find((n: any) => n.id === "workspace_root")) {
-             nodes.push({ id: "workspace_root", name: `${agentName} Root`, val: 20 });
-          }
-          
-          const links = files.map((file: string) => ({ source: "workspace_root", target: file }));
-
-          setGraphData({ nodes, links } as any);
-          setContent(`# Knowledge Base: ${agentName}\n\nEste visor está conectado al sistema de archivos local. Actualmente hay ${files.length} archivos Markdown en la raíz del workspace de este agente.\n\n### Archivos Encontrados:\n${files.map((f: string) => `- ${f}`).join('\n')}`);
-        } catch (error) {
-          console.error(error);
-          setContent(`Error cargando la base de conocimiento real de ${agentName}.`);
-        }
+      // Mock robusto para evitar errores de red en el frontend.
+      // El frontend SPA no tiene permisos de ejecución bash directa por seguridad CORS/Role
+      // Reemplazado por un mockup mientras se implementa el endpoint /api/v1/wiki/
+      const mockGraph = () => {
+        const mockFiles = ["index.md", "log.md", "IDENTITY.md", "SOUL.md", "AGENTS.md", "TOOLS.md", "MEMORY.md"];
+        const nodes = mockFiles.map(f => ({ id: f, name: f, val: 15 }));
+        nodes.push({ id: "ROOT", name: `${agentName} Vault`, val: 30 });
+        
+        const links = mockFiles.map(f => ({ source: "ROOT", target: f }));
+        // Some random cross links
+        links.push({ source: "index.md", target: "log.md" });
+        links.push({ source: "SOUL.md", target: "AGENTS.md" });
+        
+        setGraphData({ nodes, links } as any);
+        setContent(`# Knowledge Base: ${agentName}\n\nConexión establecida con la bóveda de conocimiento (Modo: Safe-Mock).\n\n### Documentos detectados:\n${mockFiles.map(f => `- **${f}**`).join('\n')}\n\n*Nota: El renderizado está aislado en el cliente. Para lectura de disco real, la API del gateway debe exponer el endpoint de Wiki.*`);
       };
-
-      fetchRealGraph();
+      
+      mockGraph();
     }
   }, [isOpen, agentName, agentId]);
 
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent className="max-w-5xl h-[80vh] flex flex-col bg-zinc-950 border-gray-800">
-        <DialogHeader className="flex flex-row items-center justify-between border-b border-gray-800 pb-4">
+      <DialogContent className="max-w-5xl h-[80vh] flex flex-col bg-zinc-950 border border-purple-500/20 shadow-2xl shadow-purple-900/20">
+        <DialogHeader className="flex flex-row items-center justify-between border-b border-gray-800 pb-4 relative">
           <DialogTitle className="text-xl font-bold text-gray-200">
             Wiki Explorer: {agentName}
           </DialogTitle>
           <div className="flex gap-2">
             <button 
               onClick={() => setViewMode("text")}
-              className={`px-3 py-1 text-sm rounded ${viewMode === "text" ? "bg-purple-600 text-white" : "bg-zinc-800 text-gray-400"}`}
+              className={`px-3 py-1 text-sm rounded transition-colors ${viewMode === "text" ? "bg-purple-600 text-white" : "bg-zinc-800 text-gray-400 hover:bg-zinc-700"}`}
             >
               Document
             </button>
             <button 
               onClick={() => setViewMode("graph")}
-              className={`px-3 py-1 text-sm rounded ${viewMode === "graph" ? "bg-purple-600 text-white" : "bg-zinc-800 text-gray-400"}`}
+              className={`px-3 py-1 text-sm rounded transition-colors ${viewMode === "graph" ? "bg-purple-600 text-white" : "bg-zinc-800 text-gray-400 hover:bg-zinc-700"}`}
             >
               Graph View
             </button>
           </div>
+          <button onClick={onClose} className="absolute -top-2 -right-2 text-gray-400 hover:text-white bg-zinc-800 rounded-full w-8 h-8 flex items-center justify-center border border-gray-700">✕</button>
         </DialogHeader>
         
         <div className="flex-1 overflow-auto p-4 text-gray-300">
@@ -86,15 +69,16 @@ export function WikiViewerModal({ agentId, agentName, isOpen, onClose }: WikiVie
               <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>
             </div>
           ) : (
-            <div className="w-full h-full flex items-center justify-center bg-zinc-900 rounded-lg overflow-hidden">
+            <div className="w-full h-full flex items-center justify-center bg-zinc-900 rounded-lg overflow-hidden border border-zinc-800">
               <ForceGraph2D
                 graphData={graphData}
-                nodeAutoColorBy="group"
+                nodeAutoColorBy="id"
                 nodeLabel="name"
-                width={800}
+                width={900}
                 height={500}
                 backgroundColor="#18181b"
                 linkColor={() => "#4c1d95"}
+                nodeRelSize={6}
               />
             </div>
           )}

--- a/src/components/console/agents/WikiViewerModal.tsx
+++ b/src/components/console/agents/WikiViewerModal.tsx
@@ -35,10 +35,10 @@ export function WikiViewerModal({ agentId, agentName, isOpen, onClose }: WikiVie
         const adapter = getAdapter();
         
         // Use standard File API from OpenClaw (via agentsFilesList and agentsFilesGet)
-        const fileNames = await adapter.agentsFilesList(agentId);
+        const fileListResult = await adapter.agentsFilesList(agentId);
         
-        // Filter only markdown files
-        const mdFiles = fileNames.filter((name: string) => name.endsWith('.md'));
+        // Filter only markdown files based on AgentFilesListResult structure
+        const mdFiles = (fileListResult.files || []).filter((f) => f.name.endsWith('.md'));
         
         if (mdFiles.length === 0) {
            if (mounted) {
@@ -52,12 +52,12 @@ export function WikiViewerModal({ agentId, agentName, isOpen, onClose }: WikiVie
         const loadedFiles: WikiFile[] = [];
         
         // Fetch content for each md file
-        for (const fileName of mdFiles) {
+        for (const fileInfo of mdFiles) {
           try {
-            const content = await adapter.agentsFilesGet(agentId, fileName);
-            loadedFiles.push({ name: fileName, content: content || "*Vacío*" });
+            const result = await adapter.agentsFilesGet(agentId, fileInfo.name);
+            loadedFiles.push({ name: fileInfo.name, content: result.file.content || "*Vacío*" });
           } catch (e) {
-            console.warn(`Failed to read ${fileName}`, e);
+            console.warn(`Failed to read ${fileInfo.name}`, e);
           }
         }
         

--- a/src/components/console/agents/WikiViewerModal.tsx
+++ b/src/components/console/agents/WikiViewerModal.tsx
@@ -17,7 +17,7 @@ const MOCK_FILES = [
   { name: "MEMORY.md", content: "# MEMORY.md\n\nHechos durables:\n- SitioUno es la matriz.\n- Jean es el CEO." }
 ];
 
-export function WikiViewerModal({ agentName, isOpen, onClose }: WikiViewerModalProps) {
+export function WikiViewerModal({ agentId, agentName, isOpen, onClose }: WikiViewerModalProps) {
   const [activeFile, setActiveFile] = useState(MOCK_FILES[0]);
 
   useEffect(() => {

--- a/src/components/console/setupgcp/ChannelsAdminView.tsx
+++ b/src/components/console/setupgcp/ChannelsAdminView.tsx
@@ -1,0 +1,496 @@
+import { CheckCircle2, KeyRound, Plus, RefreshCw, Send, Trash2, XCircle } from "lucide-react";
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { ConfirmDialog } from "@/components/console/shared/ConfirmDialog";
+import { EmptyState } from "@/components/console/shared/EmptyState";
+import { ErrorState } from "@/components/console/shared/ErrorState";
+import { LoadingState } from "@/components/console/shared/LoadingState";
+import type { ChannelTestResult, NotificationChannel } from "@/lib/registry-api-client";
+import { useSetupGcpStore } from "@/store/console-stores/setupgcp-store";
+
+export function ChannelsAdminView() {
+  const { t } = useTranslation("console");
+  const items = useSetupGcpStore((s) => s.channelItems);
+  const loading = useSetupGcpStore((s) => s.channelsLoading);
+  const error = useSetupGcpStore((s) => s.channelsError);
+  const inFlight = useSetupGcpStore((s) => s.channelActionInFlight);
+  const lastTest = useSetupGcpStore((s) => s.lastChannelTest);
+  const fetchChannels = useSetupGcpStore((s) => s.fetchChannels);
+  const createChannel = useSetupGcpStore((s) => s.createChannel);
+  const deleteChannel = useSetupGcpStore((s) => s.deleteChannel);
+  const setSecret = useSetupGcpStore((s) => s.setChannelSecret);
+  const updateChannel = useSetupGcpStore((s) => s.updateChannel);
+  const testChannel = useSetupGcpStore((s) => s.testChannel);
+  const configured = useSetupGcpStore((s) => s.configured);
+
+  const [createOpen, setCreateOpen] = useState(false);
+  const [deleteTarget, setDeleteTarget] = useState<NotificationChannel | null>(null);
+
+  useEffect(() => {
+    if (configured) void fetchChannels();
+  }, [configured, fetchChannels]);
+
+  return (
+    <section className="space-y-4 rounded-lg border border-gray-200 bg-white p-6 dark:border-gray-700 dark:bg-gray-800">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h3 className="text-base font-semibold text-gray-900 dark:text-gray-100">
+            {t("setupGcp.channels.title")}
+          </h3>
+          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+            {t("setupGcp.channels.description")}
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={() => fetchChannels()}
+            disabled={loading || !configured}
+            className="flex items-center gap-1.5 rounded-md border border-gray-300 px-3 py-1.5 text-xs font-medium text-gray-600 hover:bg-gray-50 disabled:opacity-50 dark:border-gray-600 dark:text-gray-400 dark:hover:bg-gray-700 transition-colors"
+          >
+            <RefreshCw className={`h-3.5 w-3.5 ${loading ? "animate-spin" : ""}`} />
+            {t("setupGcp.actions.refresh")}
+          </button>
+          <button
+            type="button"
+            onClick={() => setCreateOpen(true)}
+            disabled={!configured}
+            className="flex items-center gap-1.5 rounded-md bg-blue-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-blue-700 disabled:opacity-50 transition-colors"
+          >
+            <Plus className="h-3.5 w-3.5" />
+            {t("setupGcp.actions.addChannel")}
+          </button>
+        </div>
+      </div>
+
+      {!configured ? (
+        <NotConfiguredHint />
+      ) : loading && items.length === 0 ? (
+        <LoadingState />
+      ) : error && items.length === 0 ? (
+        <ErrorState message={error} onRetry={() => fetchChannels()} />
+      ) : items.length === 0 ? (
+        <EmptyState
+          icon={Send}
+          title={t("setupGcp.channels.empty.title")}
+          description={t("setupGcp.channels.empty.description")}
+          action={{ label: t("setupGcp.actions.addChannel"), onClick: () => setCreateOpen(true) }}
+        />
+      ) : (
+        <ul className="space-y-2">
+          {items.map((ch) => (
+            <ChannelRow
+              key={ch.id}
+              channel={ch}
+              busy={Boolean(inFlight[ch.id])}
+              testResult={lastTest[ch.id] ?? null}
+              onSetSecret={(secret) => setSecret(ch.id, secret)}
+              onTest={(message) => testChannel(ch.id, message)}
+              onToggle={(enabled) => updateChannel(ch.id, { enabled })}
+              onDelete={() => setDeleteTarget(ch)}
+            />
+          ))}
+        </ul>
+      )}
+
+      <CreateChannelDialog
+        open={createOpen}
+        onClose={() => setCreateOpen(false)}
+        onCreate={async (body, secretValue) => {
+          const created = await createChannel(body);
+          if (created && secretValue) {
+            await setSecret(created.id, secretValue);
+          }
+          setCreateOpen(false);
+        }}
+      />
+
+      <ConfirmDialog
+        open={deleteTarget !== null}
+        title={t("setupGcp.channels.deleteDialog.title")}
+        description={t("setupGcp.channels.deleteDialog.description", {
+          name: deleteTarget?.name ?? "",
+        })}
+        variant="danger"
+        onCancel={() => setDeleteTarget(null)}
+        onConfirm={async () => {
+          if (deleteTarget) await deleteChannel(deleteTarget.id);
+          setDeleteTarget(null);
+        }}
+      />
+    </section>
+  );
+}
+
+function NotConfiguredHint() {
+  const { t } = useTranslation("console");
+  return (
+    <div className="rounded-md border border-amber-300 bg-amber-50 p-3 text-sm text-amber-900 dark:border-amber-900/50 dark:bg-amber-950/30 dark:text-amber-200">
+      <p className="font-medium">{t("setupGcp.notConfigured.title")}</p>
+      <p className="mt-1 text-xs leading-relaxed">{t("setupGcp.notConfigured.body")}</p>
+    </div>
+  );
+}
+
+interface ChannelRowProps {
+  channel: NotificationChannel;
+  busy: boolean;
+  testResult: ChannelTestResult | null;
+  onSetSecret: (secret: string) => Promise<void> | void;
+  onTest: (message?: string) => Promise<ChannelTestResult | null>;
+  onToggle: (enabled: boolean) => Promise<void> | void;
+  onDelete: () => void;
+}
+
+function ChannelRow({
+  channel,
+  busy,
+  testResult,
+  onSetSecret,
+  onTest,
+  onToggle,
+  onDelete,
+}: ChannelRowProps) {
+  const { t } = useTranslation("console");
+  const [secretMode, setSecretMode] = useState(false);
+  const [secret, setSecret] = useState("");
+  const [testMode, setTestMode] = useState(false);
+  const [testMessage, setTestMessage] = useState("");
+
+  const chatId =
+    typeof channel.config?.chat_id === "string" || typeof channel.config?.chat_id === "number"
+      ? String(channel.config.chat_id)
+      : null;
+
+  return (
+    <li className="rounded-md border border-gray-200 bg-gray-50 dark:border-gray-700 dark:bg-gray-900/40">
+      <div className="flex items-start gap-3 px-3 py-2">
+        <span className="mt-0.5 text-lg">{kindIcon(channel.kind)}</span>
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <span className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+              {channel.name}
+            </span>
+            <span className="rounded bg-gray-200 px-1.5 py-0.5 text-[10px] font-mono text-gray-600 dark:bg-gray-700 dark:text-gray-300">
+              {channel.kind}
+            </span>
+            <span
+              className={`rounded-full px-2 py-0.5 text-[10px] font-medium ${
+                channel.enabled
+                  ? "bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-200"
+                  : "bg-gray-200 text-gray-600 dark:bg-gray-700 dark:text-gray-300"
+              }`}
+            >
+              {channel.enabled ? t("setupGcp.channels.enabled") : t("setupGcp.channels.disabled")}
+            </span>
+            <span className="rounded-full px-2 py-0.5 text-[10px] font-medium bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-200">
+              {channel.scope}
+            </span>
+          </div>
+          <p className="mt-0.5 text-xs text-gray-500 dark:text-gray-400">
+            {chatId && (
+              <>
+                <span className="font-mono">chat_id: {chatId}</span> ·{" "}
+              </>
+            )}
+            {channel.secret_ref ? (
+              <span className="font-mono">{channel.secret_ref}</span>
+            ) : (
+              <span className="italic">{t("setupGcp.channels.noSecret")}</span>
+            )}
+            {channel.last_test_at && (
+              <>
+                {" "}
+                · {t("setupGcp.channels.lastTest")}{" "}
+                {new Date(channel.last_test_at).toLocaleString()}
+              </>
+            )}
+          </p>
+          {testResult && (
+            <p
+              className={`mt-1 text-xs ${
+                testResult.ok
+                  ? "text-emerald-600 dark:text-emerald-400"
+                  : "text-red-600 dark:text-red-400"
+              }`}
+            >
+              {testResult.ok ? (
+                <CheckCircle2 className="mr-1 inline h-3 w-3" />
+              ) : (
+                <XCircle className="mr-1 inline h-3 w-3" />
+              )}
+              {testResult.ok
+                ? t("setupGcp.channels.testOk")
+                : t("setupGcp.channels.testFailed", {
+                    detail:
+                      typeof testResult.detail === "string"
+                        ? testResult.detail
+                        : JSON.stringify(testResult.detail ?? {}),
+                  })}
+            </p>
+          )}
+        </div>
+        <div className="flex shrink-0 items-center gap-1.5">
+          <button
+            type="button"
+            disabled={busy}
+            onClick={() => onToggle(!channel.enabled)}
+            className="rounded-md border border-gray-300 px-2 py-1 text-xs font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700 transition-colors"
+          >
+            {channel.enabled ? t("setupGcp.actions.disable") : t("setupGcp.actions.enable")}
+          </button>
+          <button
+            type="button"
+            disabled={busy}
+            onClick={() => setSecretMode((v) => !v)}
+            className="flex items-center gap-1 rounded-md border border-gray-300 px-2 py-1 text-xs font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700 transition-colors"
+          >
+            <KeyRound className="h-3 w-3" />
+            {t("setupGcp.actions.setSecret")}
+          </button>
+          <button
+            type="button"
+            disabled={busy || !channel.secret_ref}
+            onClick={() => setTestMode((v) => !v)}
+            className="flex items-center gap-1 rounded-md border border-blue-300 px-2 py-1 text-xs font-medium text-blue-600 hover:bg-blue-50 disabled:opacity-50 dark:border-blue-700 dark:text-blue-400 dark:hover:bg-blue-900/20 transition-colors"
+          >
+            <Send className="h-3 w-3" />
+            {t("setupGcp.actions.test")}
+          </button>
+          <button
+            type="button"
+            disabled={busy}
+            onClick={onDelete}
+            className="flex items-center gap-1 rounded-md border border-red-300 px-2 py-1 text-xs font-medium text-red-600 hover:bg-red-50 disabled:opacity-50 dark:border-red-700 dark:text-red-400 dark:hover:bg-red-900/20 transition-colors"
+          >
+            <Trash2 className="h-3 w-3" />
+          </button>
+        </div>
+      </div>
+
+      {secretMode && (
+        <div className="border-t border-gray-200 bg-white px-3 py-3 dark:border-gray-700 dark:bg-gray-800">
+          <label className="mb-1 block text-xs font-medium text-gray-700 dark:text-gray-300">
+            {t("setupGcp.channels.secretValue")}
+          </label>
+          <input
+            type="password"
+            value={secret}
+            onChange={(e) => setSecret(e.target.value)}
+            placeholder={t("setupGcp.channels.secretPlaceholder")}
+            className="w-full rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
+          />
+          <p className="mt-1 text-[11px] text-gray-500 dark:text-gray-400">
+            {t("setupGcp.channels.secretHint")}
+          </p>
+          <div className="mt-2 flex justify-end gap-2">
+            <button
+              type="button"
+              onClick={() => {
+                setSecretMode(false);
+                setSecret("");
+              }}
+              className="rounded-md border border-gray-300 px-3 py-1.5 text-xs font-medium text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700 transition-colors"
+            >
+              {t("setupGcp.actions.cancel")}
+            </button>
+            <button
+              type="button"
+              disabled={busy || !secret.trim()}
+              onClick={async () => {
+                await onSetSecret(secret);
+                setSecretMode(false);
+                setSecret("");
+              }}
+              className="rounded-md bg-blue-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-blue-700 disabled:opacity-50 transition-colors"
+            >
+              {t("setupGcp.actions.save")}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {testMode && (
+        <div className="border-t border-gray-200 bg-white px-3 py-3 dark:border-gray-700 dark:bg-gray-800">
+          <label className="mb-1 block text-xs font-medium text-gray-700 dark:text-gray-300">
+            {t("setupGcp.channels.testMessage")}
+          </label>
+          <input
+            type="text"
+            value={testMessage}
+            onChange={(e) => setTestMessage(e.target.value)}
+            placeholder={t("setupGcp.channels.testMessagePlaceholder")}
+            className="w-full rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
+          />
+          <div className="mt-2 flex justify-end gap-2">
+            <button
+              type="button"
+              onClick={() => {
+                setTestMode(false);
+                setTestMessage("");
+              }}
+              className="rounded-md border border-gray-300 px-3 py-1.5 text-xs font-medium text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700 transition-colors"
+            >
+              {t("setupGcp.actions.cancel")}
+            </button>
+            <button
+              type="button"
+              disabled={busy}
+              onClick={async () => {
+                await onTest(testMessage.trim() || undefined);
+                setTestMode(false);
+              }}
+              className="rounded-md bg-blue-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-blue-700 disabled:opacity-50 transition-colors"
+            >
+              {t("setupGcp.actions.sendTest")}
+            </button>
+          </div>
+        </div>
+      )}
+    </li>
+  );
+}
+
+function kindIcon(kind: string): string {
+  if (kind === "telegram") return "✈️";
+  if (kind === "discord") return "🎮";
+  if (kind === "slack") return "💬";
+  return "🔔";
+}
+
+interface CreateChannelDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onCreate: (
+    body: { kind: string; name: string; config: Record<string, unknown>; scope?: string },
+    secretValue: string,
+  ) => Promise<void>;
+}
+
+function CreateChannelDialog({ open, onClose, onCreate }: CreateChannelDialogProps) {
+  const { t } = useTranslation("console");
+  const [kind, setKind] = useState("telegram");
+  const [name, setName] = useState("");
+  const [chatId, setChatId] = useState("");
+  const [scope, setScope] = useState("admin");
+  const [secret, setSecret] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  if (!open) return null;
+
+  const reset = () => {
+    setKind("telegram");
+    setName("");
+    setChatId("");
+    setScope("admin");
+    setSecret("");
+    setSubmitting(false);
+  };
+
+  const handleClose = () => {
+    reset();
+    onClose();
+  };
+
+  const canSubmit =
+    name.trim().length > 0 &&
+    (kind !== "telegram" || (chatId.trim().length > 0 && secret.trim().length > 0));
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
+      <div className="w-full max-w-md rounded-lg border border-gray-200 bg-white p-6 shadow-xl dark:border-gray-700 dark:bg-gray-800">
+        <h3 className="mb-4 text-lg font-semibold text-gray-900 dark:text-gray-100">
+          {t("setupGcp.channels.createDialog.title")}
+        </h3>
+        <div className="space-y-3">
+          <Field label={t("setupGcp.channels.fields.kind")}>
+            <select
+              value={kind}
+              onChange={(e) => setKind(e.target.value)}
+              className="w-full rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
+            >
+              <option value="telegram">Telegram</option>
+              <option value="discord">Discord</option>
+              <option value="slack">Slack</option>
+            </select>
+          </Field>
+          <Field label={t("setupGcp.channels.fields.name")}>
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder={t("setupGcp.channels.fields.namePlaceholder")}
+              className="w-full rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
+            />
+          </Field>
+          <Field label={t("setupGcp.channels.fields.scope")}>
+            <select
+              value={scope}
+              onChange={(e) => setScope(e.target.value)}
+              className="w-full rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
+            >
+              <option value="admin">admin</option>
+              <option value="branch">branch</option>
+            </select>
+          </Field>
+          {kind === "telegram" && (
+            <>
+              <Field label={t("setupGcp.channels.fields.chatId")}>
+                <input
+                  type="text"
+                  value={chatId}
+                  onChange={(e) => setChatId(e.target.value)}
+                  placeholder={t("setupGcp.channels.fields.chatIdPlaceholder")}
+                  className="w-full rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
+                />
+              </Field>
+              <Field label={t("setupGcp.channels.fields.botToken")}>
+                <input
+                  type="password"
+                  value={secret}
+                  onChange={(e) => setSecret(e.target.value)}
+                  placeholder={t("setupGcp.channels.fields.botTokenPlaceholder")}
+                  className="w-full rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
+                />
+              </Field>
+            </>
+          )}
+        </div>
+        <div className="mt-6 flex justify-end gap-3">
+          <button
+            type="button"
+            onClick={handleClose}
+            className="rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700 transition-colors"
+          >
+            {t("setupGcp.actions.cancel")}
+          </button>
+          <button
+            type="button"
+            disabled={!canSubmit || submitting}
+            onClick={async () => {
+              setSubmitting(true);
+              const config: Record<string, unknown> = {};
+              if (kind === "telegram") config.chat_id = chatId.trim();
+              await onCreate({ kind, name: name.trim(), config, scope }, secret.trim());
+              reset();
+            }}
+            className="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50 transition-colors"
+          >
+            {submitting ? t("setupGcp.actions.creating") : t("setupGcp.actions.create")}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div>
+      <label className="mb-1 block text-xs font-medium text-gray-700 dark:text-gray-300">
+        {label}
+      </label>
+      {children}
+    </div>
+  );
+}

--- a/src/components/console/setupgcp/PairingRequestsView.tsx
+++ b/src/components/console/setupgcp/PairingRequestsView.tsx
@@ -1,0 +1,303 @@
+import {
+  CheckCircle2,
+  ChevronDown,
+  ChevronRight,
+  RefreshCw,
+  ShieldCheck,
+  XCircle,
+} from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { EmptyState } from "@/components/console/shared/EmptyState";
+import { ErrorState } from "@/components/console/shared/ErrorState";
+import { LoadingState } from "@/components/console/shared/LoadingState";
+import type { PairingRequest, PairingStatus } from "@/lib/registry-api-client";
+import { useSetupGcpStore } from "@/store/console-stores/setupgcp-store";
+
+const STATUS_OPTIONS: Array<PairingStatus | "all"> = [
+  "pending",
+  "approved",
+  "rejected",
+  "smoke_passed",
+  "smoke_failed",
+  "all",
+];
+
+interface PairingRequestsViewProps {
+  defaultDecidedBy: string;
+}
+
+export function PairingRequestsView({ defaultDecidedBy }: PairingRequestsViewProps) {
+  const { t } = useTranslation("console");
+  const items = useSetupGcpStore((s) => s.pairingItems);
+  const loading = useSetupGcpStore((s) => s.pairingLoading);
+  const error = useSetupGcpStore((s) => s.pairingError);
+  const filter = useSetupGcpStore((s) => s.pairingFilter);
+  const inFlight = useSetupGcpStore((s) => s.pairingActionInFlight);
+  const fetchPairing = useSetupGcpStore((s) => s.fetchPairing);
+  const setFilter = useSetupGcpStore((s) => s.setPairingFilter);
+  const approve = useSetupGcpStore((s) => s.approvePairing);
+  const reject = useSetupGcpStore((s) => s.rejectPairing);
+  const configured = useSetupGcpStore((s) => s.configured);
+
+  useEffect(() => {
+    if (configured) void fetchPairing();
+  }, [configured, fetchPairing]);
+
+  const counts = useMemo(() => {
+    const c: Record<string, number> = {};
+    for (const it of items) c[it.status] = (c[it.status] ?? 0) + 1;
+    return c;
+  }, [items]);
+
+  return (
+    <section className="space-y-4 rounded-lg border border-gray-200 bg-white p-6 dark:border-gray-700 dark:bg-gray-800">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h3 className="text-base font-semibold text-gray-900 dark:text-gray-100">
+            {t("setupGcp.pairing.title")}
+          </h3>
+          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+            {t("setupGcp.pairing.description")}
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => fetchPairing()}
+          disabled={loading || !configured}
+          className="flex items-center gap-1.5 rounded-md border border-gray-300 px-3 py-1.5 text-xs font-medium text-gray-600 hover:bg-gray-50 disabled:opacity-50 dark:border-gray-600 dark:text-gray-400 dark:hover:bg-gray-700 transition-colors"
+        >
+          <RefreshCw className={`h-3.5 w-3.5 ${loading ? "animate-spin" : ""}`} />
+          {t("setupGcp.actions.refresh")}
+        </button>
+      </div>
+
+      <div className="flex flex-wrap gap-2">
+        {STATUS_OPTIONS.map((opt) => {
+          const isActive = filter === opt;
+          const count = opt === "all" ? items.length : (counts[opt] ?? 0);
+          return (
+            <button
+              key={opt}
+              type="button"
+              onClick={() => setFilter(opt)}
+              className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
+                isActive
+                  ? "bg-blue-600 text-white"
+                  : "border border-gray-300 text-gray-600 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-400 dark:hover:bg-gray-700"
+              }`}
+            >
+              {t(`setupGcp.pairing.statusFilter.${opt}`)}
+              {opt !== "all" && filter === opt && (
+                <span className="ml-1 opacity-80">({count})</span>
+              )}
+            </button>
+          );
+        })}
+      </div>
+
+      {!configured ? (
+        <NotConfiguredHint />
+      ) : loading && items.length === 0 ? (
+        <LoadingState />
+      ) : error && items.length === 0 ? (
+        <ErrorState message={error} onRetry={() => fetchPairing()} />
+      ) : items.length === 0 ? (
+        <EmptyState
+          icon={ShieldCheck}
+          title={t("setupGcp.pairing.empty.title")}
+          description={t("setupGcp.pairing.empty.description")}
+        />
+      ) : (
+        <ul className="space-y-2">
+          {items.map((item) => (
+            <PairingRow
+              key={item.id}
+              item={item}
+              busy={Boolean(inFlight[item.id])}
+              defaultDecidedBy={defaultDecidedBy}
+              onApprove={(decidedBy) => approve(item.id, decidedBy)}
+              onReject={(decidedBy, reason) => reject(item.id, decidedBy, reason)}
+            />
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+function NotConfiguredHint() {
+  const { t } = useTranslation("console");
+  return (
+    <div className="rounded-md border border-amber-300 bg-amber-50 p-3 text-sm text-amber-900 dark:border-amber-900/50 dark:bg-amber-950/30 dark:text-amber-200">
+      <p className="font-medium">{t("setupGcp.notConfigured.title")}</p>
+      <p className="mt-1 text-xs leading-relaxed">{t("setupGcp.notConfigured.body")}</p>
+    </div>
+  );
+}
+
+interface PairingRowProps {
+  item: PairingRequest;
+  busy: boolean;
+  defaultDecidedBy: string;
+  onApprove: (decidedBy: string) => Promise<void> | void;
+  onReject: (decidedBy: string, reason: string) => Promise<void> | void;
+}
+
+function PairingRow({ item, busy, defaultDecidedBy, onApprove, onReject }: PairingRowProps) {
+  const { t } = useTranslation("console");
+  const [expanded, setExpanded] = useState(false);
+  const [rejectMode, setRejectMode] = useState(false);
+  const [reason, setReason] = useState("");
+
+  const isPending = item.status === "pending";
+
+  return (
+    <li className="rounded-md border border-gray-200 bg-gray-50 dark:border-gray-700 dark:bg-gray-900/40">
+      <div className="flex items-center gap-3 px-3 py-2">
+        <button
+          type="button"
+          onClick={() => setExpanded((v) => !v)}
+          className="flex h-6 w-6 items-center justify-center rounded text-gray-400 hover:text-gray-700 dark:hover:text-gray-200"
+          aria-label={expanded ? "Collapse" : "Expand"}
+        >
+          {expanded ? <ChevronDown className="h-4 w-4" /> : <ChevronRight className="h-4 w-4" />}
+        </button>
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <span className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+              {item.branch_id}
+            </span>
+            <span className="rounded bg-gray-200 px-1.5 py-0.5 text-[10px] font-mono text-gray-600 dark:bg-gray-700 dark:text-gray-300">
+              {item.hostname}
+            </span>
+            <StatusPill status={item.status} />
+          </div>
+          <p className="mt-0.5 truncate text-xs text-gray-500 dark:text-gray-400">
+            {item.tailscale_ip} · {t("setupGcp.pairing.coordinator")} {item.coordinator_agent_id} ·{" "}
+            {new Date(item.requested_at).toLocaleString()}
+          </p>
+        </div>
+        {isPending && !rejectMode && (
+          <div className="flex shrink-0 items-center gap-2">
+            <button
+              type="button"
+              disabled={busy}
+              onClick={() => onApprove(defaultDecidedBy)}
+              className="flex items-center gap-1 rounded-md bg-emerald-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-emerald-700 disabled:opacity-50 transition-colors"
+            >
+              <CheckCircle2 className="h-3.5 w-3.5" />
+              {t("setupGcp.actions.approve")}
+            </button>
+            <button
+              type="button"
+              disabled={busy}
+              onClick={() => setRejectMode(true)}
+              className="flex items-center gap-1 rounded-md border border-red-300 px-3 py-1.5 text-xs font-medium text-red-600 hover:bg-red-50 disabled:opacity-50 dark:border-red-700 dark:text-red-400 dark:hover:bg-red-900/20 transition-colors"
+            >
+              <XCircle className="h-3.5 w-3.5" />
+              {t("setupGcp.actions.reject")}
+            </button>
+          </div>
+        )}
+      </div>
+
+      {isPending && rejectMode && (
+        <div className="border-t border-gray-200 bg-white px-3 py-3 dark:border-gray-700 dark:bg-gray-800">
+          <label className="mb-1 block text-xs font-medium text-gray-700 dark:text-gray-300">
+            {t("setupGcp.pairing.rejectReason")}
+          </label>
+          <input
+            type="text"
+            value={reason}
+            onChange={(e) => setReason(e.target.value)}
+            placeholder={t("setupGcp.pairing.rejectReasonPlaceholder")}
+            className="w-full rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
+          />
+          <div className="mt-2 flex justify-end gap-2">
+            <button
+              type="button"
+              onClick={() => {
+                setRejectMode(false);
+                setReason("");
+              }}
+              className="rounded-md border border-gray-300 px-3 py-1.5 text-xs font-medium text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700 transition-colors"
+            >
+              {t("setupGcp.actions.cancel")}
+            </button>
+            <button
+              type="button"
+              disabled={busy || !reason.trim()}
+              onClick={async () => {
+                await onReject(defaultDecidedBy, reason.trim());
+                setRejectMode(false);
+                setReason("");
+              }}
+              className="rounded-md bg-red-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-red-700 disabled:opacity-50 transition-colors"
+            >
+              {t("setupGcp.actions.confirmReject")}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {expanded && (
+        <div className="border-t border-gray-200 bg-white px-3 py-3 text-xs dark:border-gray-700 dark:bg-gray-800">
+          <DetailGrid item={item} />
+        </div>
+      )}
+    </li>
+  );
+}
+
+function StatusPill({ status }: { status: PairingStatus }) {
+  const { t } = useTranslation("console");
+  const color: Record<PairingStatus, string> = {
+    pending: "bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-200",
+    approved: "bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-200",
+    rejected: "bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-200",
+    smoke_passed: "bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-200",
+    smoke_failed: "bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-200",
+  };
+  return (
+    <span className={`rounded-full px-2 py-0.5 text-[10px] font-medium ${color[status]}`}>
+      {t(`setupGcp.pairing.status.${status}`)}
+    </span>
+  );
+}
+
+function DetailGrid({ item }: { item: PairingRequest }) {
+  const { t } = useTranslation("console");
+  const rows: Array<[string, string]> = [
+    [t("setupGcp.pairing.fields.delegateUrl"), item.delegate_url],
+    [t("setupGcp.pairing.fields.allowedAgents"), item.allowed_agents.join(", ") || "—"],
+    [t("setupGcp.pairing.fields.tokenFingerprint"), item.delegation_token_fingerprint],
+    [t("setupGcp.pairing.fields.decidedBy"), item.decided_by ?? "—"],
+    [
+      t("setupGcp.pairing.fields.decidedAt"),
+      item.decided_at ? new Date(item.decided_at).toLocaleString() : "—",
+    ],
+  ];
+  return (
+    <dl className="grid grid-cols-1 gap-y-1 sm:grid-cols-[180px_1fr]">
+      {rows.map(([k, v]) => (
+        <div key={k} className="contents">
+          <dt className="text-gray-500 dark:text-gray-400">{k}</dt>
+          <dd className="font-mono text-gray-700 dark:text-gray-200 break-all">{v}</dd>
+        </div>
+      ))}
+      {item.metadata && Object.keys(item.metadata).length > 0 && (
+        <div className="contents">
+          <dt className="text-gray-500 dark:text-gray-400">
+            {t("setupGcp.pairing.fields.metadata")}
+          </dt>
+          <dd className="font-mono text-gray-700 dark:text-gray-200">
+            <pre className="whitespace-pre-wrap break-all rounded bg-gray-100 p-2 text-[11px] dark:bg-gray-900">
+              {JSON.stringify(item.metadata, null, 2)}
+            </pre>
+          </dd>
+        </div>
+      )}
+    </dl>
+  );
+}

--- a/src/components/console/setupgcp/SecretManagerNotice.tsx
+++ b/src/components/console/setupgcp/SecretManagerNotice.tsx
@@ -1,0 +1,17 @@
+import { ShieldCheck } from "lucide-react";
+import { useTranslation } from "react-i18next";
+
+export function SecretManagerNotice() {
+  const { t } = useTranslation("console");
+  return (
+    <div className="flex items-start gap-3 rounded-md border border-blue-200 bg-blue-50 p-3 text-sm text-blue-900 dark:border-blue-900/60 dark:bg-blue-950/40 dark:text-blue-200">
+      <ShieldCheck className="mt-0.5 h-4 w-4 shrink-0" />
+      <div>
+        <p className="font-medium">{t("setupGcp.secretsNotice.title")}</p>
+        <p className="mt-1 text-xs leading-relaxed text-blue-800/90 dark:text-blue-300/90">
+          {t("setupGcp.secretsNotice.body")}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/layout/ConsoleLayout.tsx
+++ b/src/components/layout/ConsoleLayout.tsx
@@ -1,4 +1,4 @@
-import { Home, Bot, Radio, Puzzle, Clock, Settings } from "lucide-react";
+import { Home, Bot, Radio, Puzzle, Clock, Settings, Cloud } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { Outlet, useLocation, useNavigate } from "react-router-dom";
 import { RestartBanner } from "@/components/shared/RestartBanner";
@@ -16,6 +16,7 @@ export function ConsoleLayout() {
     { path: "/channels", labelKey: "consoleNav.channels", icon: Radio },
     { path: "/skills", labelKey: "consoleNav.skills", icon: Puzzle },
     { path: "/cron", labelKey: "consoleNav.cron", icon: Clock },
+    { path: "/setup-gcp", labelKey: "consoleNav.setupGcp", icon: Cloud },
     { path: "/settings", labelKey: "consoleNav.settings", icon: Settings },
   ] as const;
 

--- a/src/components/layout/TopBar.tsx
+++ b/src/components/layout/TopBar.tsx
@@ -76,7 +76,7 @@ function BrandSection({
       </span>
       <div className="ml-4 flex items-center gap-2 rounded bg-zinc-900 px-3 py-1 border border-yellow-500/30 shadow-[0_0_15px_rgba(250,204,21,0.2)]">
         <div className="flex h-5 w-5 items-center justify-center rounded bg-yellow-400 text-[10px] font-bold text-zinc-900 shadow-[0_0_10px_rgba(250,204,21,0.8)]">SU</div>
-        <span className="text-xs uppercase tracking-widest text-yellow-400 drop-shadow-[0_0_8px_rgba(250,204,21,0.8)] font-bold">{BRANCH_LABEL || "SitioUno"}</span>
+        <span className="text-xs uppercase tracking-widest text-yellow-400 drop-shadow-[0_0_8px_rgba(250,204,21,0.8)] font-bold">{`${OFFICE_TITLE} - ${BRANCH_LABEL}` || "SitioUno - Sucursal Miami"}</span>
       </div>
       {isOfficePage && !isMobile && (
         <div className="ml-2 hidden items-center gap-5 text-xs text-gray-400 dark:text-gray-500 xl:flex">

--- a/src/components/layout/TopBar.tsx
+++ b/src/components/layout/TopBar.tsx
@@ -5,6 +5,8 @@ import type { ConnectionStatus, ThemeMode, PageId } from "@/gateway/types";
 import { useOfficeStore } from "@/store/office-store";
 
 const APP_VERSION = typeof __APP_VERSION__ === "string" ? __APP_VERSION__ : "dev";
+const OFFICE_TITLE = import.meta.env.VITE_OFFICE_TITLE || "OpenClaw Office";
+const BRANCH_LABEL = import.meta.env.VITE_BRANCH_LABEL || "";
 
 function getStatusConfig(
   t: (key: string) => string,
@@ -67,14 +69,14 @@ function BrandSection({
   return (
     <div className="flex min-w-0 items-center gap-3">
       <h1 className="truncate text-sm font-semibold tracking-tight text-gray-800 dark:text-gray-100">
-        OpenClaw Office
+        {OFFICE_TITLE}
       </h1>
       <span className="rounded-full bg-gray-100 px-1.5 py-0.5 text-[10px] tabular-nums text-gray-400 dark:bg-gray-800 dark:text-gray-500">
         v{APP_VERSION}
       </span>
       <div className="ml-4 flex items-center gap-2 rounded bg-zinc-900 px-3 py-1 border border-yellow-500/30 shadow-[0_0_15px_rgba(250,204,21,0.2)]">
         <div className="flex h-5 w-5 items-center justify-center rounded bg-yellow-400 text-[10px] font-bold text-zinc-900 shadow-[0_0_10px_rgba(250,204,21,0.8)]">SU</div>
-        <span className="text-xs uppercase tracking-widest text-yellow-400 drop-shadow-[0_0_8px_rgba(250,204,21,0.8)] font-bold">SitioUno - Sucursal Miami</span>
+        <span className="text-xs uppercase tracking-widest text-yellow-400 drop-shadow-[0_0_8px_rgba(250,204,21,0.8)] font-bold">{BRANCH_LABEL || "SitioUno"}</span>
       </div>
       {isOfficePage && !isMobile && (
         <div className="ml-2 hidden items-center gap-5 text-xs text-gray-400 dark:text-gray-500 xl:flex">

--- a/src/components/layout/TopBar.tsx
+++ b/src/components/layout/TopBar.tsx
@@ -72,6 +72,10 @@ function BrandSection({
       <span className="rounded-full bg-gray-100 px-1.5 py-0.5 text-[10px] tabular-nums text-gray-400 dark:bg-gray-800 dark:text-gray-500">
         v{APP_VERSION}
       </span>
+      <div className="ml-4 flex items-center gap-2 rounded bg-zinc-900 px-3 py-1 border border-yellow-500/30 shadow-[0_0_15px_rgba(250,204,21,0.2)]">
+        <div className="flex h-5 w-5 items-center justify-center rounded bg-yellow-400 text-[10px] font-bold text-zinc-900 shadow-[0_0_10px_rgba(250,204,21,0.8)]">SU</div>
+        <span className="text-xs uppercase tracking-widest text-yellow-400 drop-shadow-[0_0_8px_rgba(250,204,21,0.8)] font-bold">SitioUno - Sucursal Miami</span>
+      </div>
       {isOfficePage && !isMobile && (
         <div className="ml-2 hidden items-center gap-5 text-xs text-gray-400 dark:text-gray-500 xl:flex">
           <span>

--- a/src/components/pages/ChannelsPage.tsx
+++ b/src/components/pages/ChannelsPage.tsx
@@ -1,6 +1,7 @@
-import { RefreshCw, Inbox } from "lucide-react";
+import { RefreshCw, Inbox, Cloud } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { useNavigate } from "react-router-dom";
 import { AvailableChannelGrid } from "@/components/console/channels/AvailableChannelGrid";
 import { ChannelCard } from "@/components/console/channels/ChannelCard";
 import { ChannelConfigDialog } from "@/components/console/channels/ChannelConfigDialog";
@@ -14,6 +15,7 @@ import { useChannelsStore } from "@/store/console-stores/channels-store";
 
 export function ChannelsPage() {
   const { t } = useTranslation("console");
+  const navigate = useNavigate();
   const {
     channels,
     isLoading,
@@ -74,6 +76,23 @@ export function ChannelsPage() {
         loading={isLoading}
       />
       <ChannelStatsBar channels={channels} />
+
+      <div className="flex items-start gap-3 rounded-md border border-blue-200 bg-blue-50 p-3 text-sm text-blue-900 dark:border-blue-900/60 dark:bg-blue-950/40 dark:text-blue-200">
+        <Cloud className="mt-0.5 h-4 w-4 shrink-0" />
+        <div className="flex-1">
+          <p className="font-medium">{t("channels.gcpNotice.title")}</p>
+          <p className="mt-1 text-xs leading-relaxed text-blue-800/90 dark:text-blue-300/90">
+            {t("channels.gcpNotice.body")}
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => navigate("/setup-gcp")}
+          className="shrink-0 rounded-md border border-blue-300 px-3 py-1 text-xs font-medium text-blue-700 hover:bg-blue-100 dark:border-blue-700 dark:text-blue-300 dark:hover:bg-blue-900/40 transition-colors"
+        >
+          {t("channels.gcpNotice.cta")}
+        </button>
+      </div>
 
       {channels.length === 0 ? (
         <EmptyState

--- a/src/components/pages/SetupGcpPage.test.tsx
+++ b/src/components/pages/SetupGcpPage.test.tsx
@@ -1,41 +1,50 @@
 import { act, render, screen } from "@testing-library/react";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { SetupGcpPage } from "./SetupGcpPage";
 
-function setRuntime(url?: string, token?: string): void {
+function setRuntimeUrl(url?: string): void {
   const win = window as unknown as Record<string, unknown>;
-  if (!url && !token) {
+  if (url === undefined) {
     delete win.__OPENCLAW_CONFIG__;
     return;
   }
-  win.__OPENCLAW_CONFIG__ = { registryApiUrl: url, registryApiToken: token };
+  win.__OPENCLAW_CONFIG__ = { registryApiUrl: url };
 }
+
+const originalFetch = global.fetch;
 
 describe("SetupGcpPage", () => {
   beforeEach(() => {
-    setRuntime(undefined, undefined);
+    setRuntimeUrl(undefined);
+    // Stub fetch so the auto-loaded pairing/channels lists don't hit the network.
+    global.fetch = vi.fn(
+      async () =>
+        new Response("[]", {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    ) as unknown as typeof fetch;
   });
 
   afterEach(() => {
-    setRuntime(undefined, undefined);
+    setRuntimeUrl(undefined);
+    global.fetch = originalFetch;
+    vi.restoreAllMocks();
   });
 
   it("renders without crashing and shows the secrets notice", async () => {
     await act(async () => {
       render(<SetupGcpPage />);
     });
-    // Title from i18n (zh is the default test locale)
     expect(screen.getByRole("heading", { level: 1 })).toBeInTheDocument();
-    // Secrets notice title text appears at least once
     expect(screen.getAllByText(/Secret Manager/i).length).toBeGreaterThan(0);
   });
 
-  it("shows the not-configured hint when registry API is not configured", async () => {
+  it("shows the default Tailscale HQ base URL when no override is configured", async () => {
     await act(async () => {
       render(<SetupGcpPage />);
     });
-    // The PairingRequestsView should show the not-configured hint;
-    // the i18n key body mentions VITE_REGISTRY_API_URL
-    expect(screen.getByText(/VITE_REGISTRY_API_URL/i)).toBeInTheDocument();
+    // Default base URL is http://openclaw-hq:8781 (Tailscale hostname for HQ).
+    expect(screen.getByText(/openclaw-hq:8781/)).toBeInTheDocument();
   });
 });

--- a/src/components/pages/SetupGcpPage.test.tsx
+++ b/src/components/pages/SetupGcpPage.test.tsx
@@ -1,0 +1,41 @@
+import { act, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { SetupGcpPage } from "./SetupGcpPage";
+
+function setRuntime(url?: string, token?: string): void {
+  const win = window as unknown as Record<string, unknown>;
+  if (!url && !token) {
+    delete win.__OPENCLAW_CONFIG__;
+    return;
+  }
+  win.__OPENCLAW_CONFIG__ = { registryApiUrl: url, registryApiToken: token };
+}
+
+describe("SetupGcpPage", () => {
+  beforeEach(() => {
+    setRuntime(undefined, undefined);
+  });
+
+  afterEach(() => {
+    setRuntime(undefined, undefined);
+  });
+
+  it("renders without crashing and shows the secrets notice", async () => {
+    await act(async () => {
+      render(<SetupGcpPage />);
+    });
+    // Title from i18n (zh is the default test locale)
+    expect(screen.getByRole("heading", { level: 1 })).toBeInTheDocument();
+    // Secrets notice title text appears at least once
+    expect(screen.getAllByText(/Secret Manager/i).length).toBeGreaterThan(0);
+  });
+
+  it("shows the not-configured hint when registry API is not configured", async () => {
+    await act(async () => {
+      render(<SetupGcpPage />);
+    });
+    // The PairingRequestsView should show the not-configured hint;
+    // the i18n key body mentions VITE_REGISTRY_API_URL
+    expect(screen.getByText(/VITE_REGISTRY_API_URL/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/pages/SetupGcpPage.tsx
+++ b/src/components/pages/SetupGcpPage.tsx
@@ -1,0 +1,79 @@
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { ChannelsAdminView } from "@/components/console/setupgcp/ChannelsAdminView";
+import { PairingRequestsView } from "@/components/console/setupgcp/PairingRequestsView";
+import { SecretManagerNotice } from "@/components/console/setupgcp/SecretManagerNotice";
+import { useSetupGcpStore } from "@/store/console-stores/setupgcp-store";
+
+type Tab = "pairing" | "channels";
+
+const DEFAULT_OPERATOR_ID = "console-admin";
+
+export function SetupGcpPage() {
+  const { t } = useTranslation("console");
+  const refreshConfig = useSetupGcpStore((s) => s.refreshConfig);
+  const configured = useSetupGcpStore((s) => s.configured);
+  const baseUrl = useSetupGcpStore((s) => s.baseUrl);
+  const [tab, setTab] = useState<Tab>("pairing");
+
+  useEffect(() => {
+    refreshConfig();
+  }, [refreshConfig]);
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">
+          {t("setupGcp.title")}
+        </h1>
+        <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">{t("setupGcp.description")}</p>
+        {configured && (
+          <p className="mt-1 text-xs text-gray-400 dark:text-gray-500">
+            <span className="font-mono">{baseUrl}</span>
+          </p>
+        )}
+      </div>
+
+      <SecretManagerNotice />
+
+      <div className="flex gap-1 border-b border-gray-200 dark:border-gray-700">
+        <TabButton active={tab === "pairing"} onClick={() => setTab("pairing")}>
+          {t("setupGcp.tabs.pairing")}
+        </TabButton>
+        <TabButton active={tab === "channels"} onClick={() => setTab("channels")}>
+          {t("setupGcp.tabs.channels")}
+        </TabButton>
+      </div>
+
+      {tab === "pairing" ? (
+        <PairingRequestsView defaultDecidedBy={DEFAULT_OPERATOR_ID} />
+      ) : (
+        <ChannelsAdminView />
+      )}
+    </div>
+  );
+}
+
+function TabButton({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`-mb-px border-b-2 px-3 py-2 text-sm font-medium transition-colors ${
+        active
+          ? "border-blue-600 text-blue-600 dark:border-blue-400 dark:text-blue-400"
+          : "border-transparent text-gray-500 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-200"
+      }`}
+    >
+      {children}
+    </button>
+  );
+}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,0 +1,23 @@
+import * as React from "react";
+
+export function Dialog({ open, onOpenChange, children }: { open: boolean; onOpenChange: (open: boolean) => void; children: React.ReactNode }) {
+  if (!open) return null;
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      <div className="fixed inset-0 bg-black/80 backdrop-blur-sm" onClick={() => onOpenChange(false)} />
+      <div className="z-50 w-full max-w-5xl px-4">{children}</div>
+    </div>
+  );
+}
+
+export function DialogContent({ children, className }: { children: React.ReactNode; className?: string }) {
+  return <div className={`relative w-full rounded-lg shadow-lg ${className}`}>{children}</div>;
+}
+
+export function DialogHeader({ children, className }: { children: React.ReactNode; className?: string }) {
+  return <div className={`${className}`}>{children}</div>;
+}
+
+export function DialogTitle({ children, className }: { children: React.ReactNode; className?: string }) {
+  return <h2 className={`${className}`}>{children}</h2>;
+}

--- a/src/gateway/adapter.ts.diff
+++ b/src/gateway/adapter.ts.diff
@@ -1,0 +1,9 @@
+--- src/gateway/adapter.ts
++++ src/gateway/adapter.ts
+@@ -73,6 +73,8 @@
+   skillsStatus(agentId?: string): Promise<SkillInfo[]>;
+   skillsInstall(name: string, installId: string): Promise<SkillInstallResult>;
+   skillsUpdate(skillKey: string, patch: SkillUpdatePatch): Promise<{ ok: boolean }>;
++
++  agentFiles(agentId: string): Promise<{ name: string, content: string }[]>;
+ }

--- a/src/gateway/types.ts
+++ b/src/gateway/types.ts
@@ -274,7 +274,8 @@ export type PageId =
   | "channels"
   | "skills"
   | "cron"
-  | "settings";
+  | "settings"
+  | "setupGcp";
 
 export interface TokenSnapshot {
   timestamp: number;

--- a/src/i18n/locales/en/console.json
+++ b/src/i18n/locales/en/console.json
@@ -690,7 +690,7 @@
     },
     "notConfigured": {
       "title": "Registry API not configured",
-      "body": "Set VITE_REGISTRY_API_URL and VITE_REGISTRY_API_TOKEN, or inject window.__OPENCLAW_CONFIG__.registryApiUrl/Token at runtime."
+      "body": "Set VITE_REGISTRY_API_URL or inject window.__OPENCLAW_CONFIG__.registryApiUrl at runtime. The default targets the HQ sidecar over Tailscale (http://openclaw-hq:8781) and trusts the VPN as the perimeter — no bearer token is required."
     },
     "pairing": {
       "title": "Pending pairing requests",

--- a/src/i18n/locales/en/console.json
+++ b/src/i18n/locales/en/console.json
@@ -6,6 +6,7 @@
     "stats": {
       "channels": "Channels",
       "skills": "Skills",
+      "local_skills": "Local Skills",
       "usage": "Provider Usage",
       "uptime": "Uptime",
       "uptimeOnline": "Online"
@@ -522,6 +523,7 @@
       "files": "Files",
       "tools": "Tools",
       "skills": "Skills",
+      "local_skills": "Local Skills",
       "channels": "Channels",
       "cronJobs": "Cron Jobs"
     },

--- a/src/i18n/locales/en/console.json
+++ b/src/i18n/locales/en/console.json
@@ -73,6 +73,7 @@
     },
     "fields": {
       "botToken": "Bot Token",
+      "chatId": "Chat ID",
       "applicationId": "Application ID",
       "phoneNumber": "Phone Number",
       "appId": "App ID",
@@ -87,6 +88,7 @@
     },
     "placeholders": {
       "botToken": "Enter Bot Token",
+      "chatId": "e.g. -1001234567890",
       "applicationId": "Enter Application ID",
       "phoneNumber": "+1...",
       "appId": "Enter App ID",
@@ -116,6 +118,11 @@
     "logout": {
       "title": "Logout Channel",
       "description": "Are you sure you want to logout \"{{name}}\"? You will need to re-pair."
+    },
+    "gcpNotice": {
+      "title": "Looking for Telegram alerts and broadcast channels?",
+      "body": "Notification channels backed by GCP Secret Manager (admin Telegram bot, branch broadcast bots) are managed in Setup GCP, with Chat ID, secret rotation, and a built-in test button.",
+      "cta": "Open Setup GCP"
     }
   },
   "skills": {
@@ -668,6 +675,108 @@
       "cancel": "Cancel",
       "delete": "Delete",
       "deleting": "Deleting..."
+    }
+  },
+  "setupGcp": {
+    "title": "Setup GCP",
+    "description": "Approve new branch nodes joining the fleet and manage notification channels (Telegram, etc.) backed by GCP Secret Manager.",
+    "tabs": {
+      "pairing": "Pairing Requests",
+      "channels": "Notification Channels"
+    },
+    "secretsNotice": {
+      "title": "Secrets stay in GCP Secret Manager",
+      "body": "Bot tokens and other credentials are stored in GCP Secret Manager via the fleet-registry-api. Plaintext values are never persisted in the browser or in the registry database."
+    },
+    "notConfigured": {
+      "title": "Registry API not configured",
+      "body": "Set VITE_REGISTRY_API_URL and VITE_REGISTRY_API_TOKEN, or inject window.__OPENCLAW_CONFIG__.registryApiUrl/Token at runtime."
+    },
+    "pairing": {
+      "title": "Pending pairing requests",
+      "description": "Branch nodes that have published themselves over Tailscale and are waiting for HQ to authorize delegation.",
+      "coordinator": "coordinator",
+      "rejectReason": "Rejection reason",
+      "rejectReasonPlaceholder": "Why is this request being rejected?",
+      "empty": {
+        "title": "No requests in this state",
+        "description": "Branches that contact the registry will appear here."
+      },
+      "statusFilter": {
+        "pending": "Pending",
+        "approved": "Approved",
+        "rejected": "Rejected",
+        "smoke_passed": "Smoke OK",
+        "smoke_failed": "Smoke failed",
+        "all": "All"
+      },
+      "status": {
+        "pending": "pending",
+        "approved": "approved",
+        "rejected": "rejected",
+        "smoke_passed": "smoke ok",
+        "smoke_failed": "smoke failed"
+      },
+      "fields": {
+        "delegateUrl": "Delegate URL",
+        "allowedAgents": "Allowed agents",
+        "tokenFingerprint": "Token fingerprint",
+        "decidedBy": "Decided by",
+        "decidedAt": "Decided at",
+        "metadata": "Metadata"
+      }
+    },
+    "channels": {
+      "title": "Notification channels",
+      "description": "Channels used by HQ-Cloud and branches to send alerts. Telegram is the first supported transport.",
+      "enabled": "enabled",
+      "disabled": "disabled",
+      "noSecret": "no secret set",
+      "lastTest": "last tested",
+      "testOk": "Test message delivered.",
+      "testFailed": "Test failed: {{detail}}",
+      "secretValue": "Secret value",
+      "secretPlaceholder": "Paste bot token or webhook secret",
+      "secretHint": "Stored as a new GCP Secret Manager version. Earlier versions are kept for rollback.",
+      "testMessage": "Test message",
+      "testMessagePlaceholder": "Optional — leave blank for default ping",
+      "empty": {
+        "title": "No channels configured",
+        "description": "Add a channel to start receiving fleet notifications."
+      },
+      "createDialog": {
+        "title": "Add notification channel"
+      },
+      "fields": {
+        "kind": "Kind",
+        "name": "Display name",
+        "namePlaceholder": "e.g. Admin Bot",
+        "scope": "Scope",
+        "chatId": "Chat ID",
+        "chatIdPlaceholder": "e.g. -1001234567890",
+        "botToken": "Bot Token (initial secret)",
+        "botTokenPlaceholder": "1234567890:ABC..."
+      },
+      "deleteDialog": {
+        "title": "Delete channel",
+        "description": "Delete \"{{name}}\"? The associated GCP secret will also be removed."
+      }
+    },
+    "actions": {
+      "refresh": "Refresh",
+      "approve": "Approve",
+      "reject": "Reject",
+      "confirmReject": "Reject",
+      "cancel": "Cancel",
+      "addChannel": "Add Channel",
+      "save": "Save",
+      "create": "Create",
+      "creating": "Creating...",
+      "test": "Test",
+      "sendTest": "Send test",
+      "setSecret": "Set Secret",
+      "enable": "Enable",
+      "disable": "Disable"
     }
   }
 }

--- a/src/i18n/locales/en/layout.json
+++ b/src/i18n/locales/en/layout.json
@@ -16,6 +16,7 @@
       "cron": "Cron Tasks",
       "agents": "Agents",
       "settings": "Settings",
+      "setupGcp": "Setup GCP",
       "fallback": "Console"
     },
     "theme": {
@@ -53,6 +54,7 @@
     "channels": "Channels",
     "skills": "Skills",
     "cron": "Cron Tasks",
+    "setupGcp": "Setup GCP",
     "settings": "Settings"
   }
 }

--- a/src/i18n/locales/zh/console.json
+++ b/src/i18n/locales/zh/console.json
@@ -72,6 +72,7 @@
     },
     "fields": {
       "botToken": "Bot Token",
+      "chatId": "Chat ID",
       "applicationId": "Application ID",
       "phoneNumber": "手机号",
       "appId": "App ID",
@@ -86,6 +87,7 @@
     },
     "placeholders": {
       "botToken": "输入 Bot Token",
+      "chatId": "例如 -1001234567890",
       "applicationId": "输入 Application ID",
       "phoneNumber": "+86...",
       "appId": "输入 App ID",
@@ -115,6 +117,11 @@
     "logout": {
       "title": "登出渠道",
       "description": "确认要登出「{{name}}」吗？登出后需要重新配对。"
+    },
+    "gcpNotice": {
+      "title": "需要配置 Telegram 告警或广播通道？",
+      "body": "由 GCP Secret Manager 托管的通知渠道（管理员 Telegram Bot、分支广播 Bot 等）在「GCP 配置」中统一管理，支持 Chat ID、凭据轮换和内置测试。",
+      "cta": "打开 GCP 配置"
     }
   },
   "skills": {
@@ -666,6 +673,108 @@
       "cancel": "取消",
       "delete": "删除",
       "deleting": "删除中..."
+    }
+  },
+  "setupGcp": {
+    "title": "GCP 配置",
+    "description": "审批新接入的分支节点，并管理由 GCP Secret Manager 托管的通知渠道（Telegram 等）。",
+    "tabs": {
+      "pairing": "配对请求",
+      "channels": "通知渠道"
+    },
+    "secretsNotice": {
+      "title": "凭据保存在 GCP Secret Manager",
+      "body": "Bot Token 等凭据由 fleet-registry-api 写入 GCP Secret Manager。明文不会保存在浏览器或注册中心数据库中。"
+    },
+    "notConfigured": {
+      "title": "Registry API 未配置",
+      "body": "请设置 VITE_REGISTRY_API_URL 与 VITE_REGISTRY_API_TOKEN，或在运行时注入 window.__OPENCLAW_CONFIG__.registryApiUrl/Token。"
+    },
+    "pairing": {
+      "title": "待审批的配对请求",
+      "description": "通过 Tailscale 注册并等待 HQ 授权的分支节点。",
+      "coordinator": "协调智能体",
+      "rejectReason": "拒绝原因",
+      "rejectReasonPlaceholder": "请说明拒绝该请求的原因",
+      "empty": {
+        "title": "当前没有该状态的请求",
+        "description": "新分支接入时会显示在这里。"
+      },
+      "statusFilter": {
+        "pending": "待审批",
+        "approved": "已批准",
+        "rejected": "已拒绝",
+        "smoke_passed": "Smoke 通过",
+        "smoke_failed": "Smoke 失败",
+        "all": "全部"
+      },
+      "status": {
+        "pending": "待审批",
+        "approved": "已批准",
+        "rejected": "已拒绝",
+        "smoke_passed": "smoke 通过",
+        "smoke_failed": "smoke 失败"
+      },
+      "fields": {
+        "delegateUrl": "Delegate URL",
+        "allowedAgents": "允许的 Agent",
+        "tokenFingerprint": "委托 Token 指纹",
+        "decidedBy": "审批人",
+        "decidedAt": "审批时间",
+        "metadata": "Metadata"
+      }
+    },
+    "channels": {
+      "title": "通知渠道",
+      "description": "HQ-Cloud 与分支节点用于发送告警的渠道。当前优先支持 Telegram。",
+      "enabled": "已启用",
+      "disabled": "已禁用",
+      "noSecret": "未设置凭据",
+      "lastTest": "上次测试",
+      "testOk": "测试消息已送达。",
+      "testFailed": "测试失败：{{detail}}",
+      "secretValue": "凭据值",
+      "secretPlaceholder": "粘贴 Bot Token 或 Webhook 凭据",
+      "secretHint": "保存为 GCP Secret Manager 的新版本，旧版本会保留以便回滚。",
+      "testMessage": "测试消息",
+      "testMessagePlaceholder": "可选 — 留空则发送默认 ping",
+      "empty": {
+        "title": "尚未配置通知渠道",
+        "description": "添加渠道以开始接收 fleet 通知。"
+      },
+      "createDialog": {
+        "title": "添加通知渠道"
+      },
+      "fields": {
+        "kind": "类型",
+        "name": "显示名称",
+        "namePlaceholder": "例如 Admin Bot",
+        "scope": "Scope",
+        "chatId": "Chat ID",
+        "chatIdPlaceholder": "例如 -1001234567890",
+        "botToken": "Bot Token（初始凭据）",
+        "botTokenPlaceholder": "1234567890:ABC..."
+      },
+      "deleteDialog": {
+        "title": "删除渠道",
+        "description": "确认删除「{{name}}」？关联的 GCP Secret 也会被删除。"
+      }
+    },
+    "actions": {
+      "refresh": "刷新",
+      "approve": "批准",
+      "reject": "拒绝",
+      "confirmReject": "确认拒绝",
+      "cancel": "取消",
+      "addChannel": "添加渠道",
+      "save": "保存",
+      "create": "创建",
+      "creating": "创建中...",
+      "test": "测试",
+      "sendTest": "发送测试",
+      "setSecret": "设置凭据",
+      "enable": "启用",
+      "disable": "禁用"
     }
   }
 }

--- a/src/i18n/locales/zh/console.json
+++ b/src/i18n/locales/zh/console.json
@@ -688,7 +688,7 @@
     },
     "notConfigured": {
       "title": "Registry API 未配置",
-      "body": "请设置 VITE_REGISTRY_API_URL 与 VITE_REGISTRY_API_TOKEN，或在运行时注入 window.__OPENCLAW_CONFIG__.registryApiUrl/Token。"
+      "body": "请设置 VITE_REGISTRY_API_URL，或在运行时注入 window.__OPENCLAW_CONFIG__.registryApiUrl。默认指向 Tailscale 上的 HQ 边车（http://openclaw-hq:8781），信任边界即 VPN — 无需 Bearer 令牌。"
     },
     "pairing": {
       "title": "待审批的配对请求",

--- a/src/i18n/locales/zh/layout.json
+++ b/src/i18n/locales/zh/layout.json
@@ -16,6 +16,7 @@
       "cron": "定时任务",
       "agents": "智能体管理",
       "settings": "设置",
+      "setupGcp": "GCP 配置",
       "fallback": "控制台"
     },
     "theme": {
@@ -53,6 +54,7 @@
     "channels": "渠道",
     "skills": "技能",
     "cron": "定时任务",
+    "setupGcp": "GCP 配置",
     "settings": "设置"
   }
 }

--- a/src/lib/__tests__/registry-api-client.test.ts
+++ b/src/lib/__tests__/registry-api-client.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  channels,
+  pairing,
+  RegistryApiNotConfiguredError,
+  resolveRegistryApiConfig,
+} from "@/lib/registry-api-client";
+
+const originalFetch = global.fetch;
+
+function setRuntime(url: string | undefined, token: string | undefined): void {
+  const win = window as unknown as Record<string, unknown>;
+  if (!url && !token) {
+    delete win.__OPENCLAW_CONFIG__;
+    return;
+  }
+  win.__OPENCLAW_CONFIG__ = { registryApiUrl: url, registryApiToken: token };
+}
+
+describe("registry-api-client", () => {
+  beforeEach(() => {
+    setRuntime(undefined, undefined);
+  });
+
+  afterEach(() => {
+    setRuntime(undefined, undefined);
+    global.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it("resolves config from runtime injection and trims trailing slash", () => {
+    setRuntime("https://fleet-registry-api.example.run.app/", "abc123");
+    const cfg = resolveRegistryApiConfig();
+    expect(cfg.baseUrl).toBe("https://fleet-registry-api.example.run.app");
+    expect(cfg.token).toBe("abc123");
+    expect(cfg.configured).toBe(true);
+  });
+
+  it("reports not-configured when url or token is missing", () => {
+    setRuntime("", "");
+    const cfg = resolveRegistryApiConfig();
+    expect(cfg.configured).toBe(false);
+  });
+
+  it("throws RegistryApiNotConfiguredError when calling without config", async () => {
+    setRuntime(undefined, undefined);
+    await expect(pairing.list("pending")).rejects.toBeInstanceOf(RegistryApiNotConfiguredError);
+  });
+
+  it("issues GET with bearer token and parses JSON for pairing.list", async () => {
+    setRuntime("https://api.example.com", "tok");
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(JSON.stringify([{ id: 1, branch_id: "miami" }]), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const items = await pairing.list("pending");
+    expect(items).toEqual([{ id: 1, branch_id: "miami" }]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [calledUrl, init] = fetchMock.mock.calls[0]!;
+    expect(calledUrl).toBe("https://api.example.com/v1/pairing/requests?status_filter=pending");
+    expect((init as RequestInit).method).toBe("GET");
+    expect((init as RequestInit).headers).toMatchObject({ Authorization: "Bearer tok" });
+  });
+
+  it("posts JSON body for channels.create", async () => {
+    setRuntime("https://api.example.com", "tok");
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ id: 7, kind: "telegram", name: "Admin Bot" }), {
+          status: 201,
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const created = await channels.create({
+      kind: "telegram",
+      name: "Admin Bot",
+      config: { chat_id: "-1001" },
+      scope: "admin",
+    });
+    expect(created.id).toBe(7);
+    const [, init] = fetchMock.mock.calls[0]!;
+    expect((init as RequestInit).method).toBe("POST");
+    const body = JSON.parse((init as RequestInit).body as string);
+    expect(body).toEqual({
+      kind: "telegram",
+      name: "Admin Bot",
+      config: { chat_id: "-1001" },
+      scope: "admin",
+    });
+  });
+
+  it("rejects with RegistryApiError on non-2xx with detail", async () => {
+    setRuntime("https://api.example.com", "tok");
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ detail: "nope" }), {
+          status: 403,
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    await expect(pairing.approve(1, { decided_by: "x" })).rejects.toMatchObject({
+      name: "RegistryApiError",
+      status: 403,
+      message: "nope",
+    });
+  });
+});

--- a/src/lib/__tests__/registry-api-client.test.ts
+++ b/src/lib/__tests__/registry-api-client.test.ts
@@ -1,54 +1,51 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   channels,
+  DEFAULT_REGISTRY_API_URL,
+  notify,
   pairing,
-  RegistryApiNotConfiguredError,
   resolveRegistryApiConfig,
 } from "@/lib/registry-api-client";
 
 const originalFetch = global.fetch;
 
-function setRuntime(url: string | undefined, token: string | undefined): void {
+function setRuntimeUrl(url: string | undefined): void {
   const win = window as unknown as Record<string, unknown>;
-  if (!url && !token) {
+  if (url === undefined) {
     delete win.__OPENCLAW_CONFIG__;
     return;
   }
-  win.__OPENCLAW_CONFIG__ = { registryApiUrl: url, registryApiToken: token };
+  win.__OPENCLAW_CONFIG__ = { registryApiUrl: url };
 }
 
 describe("registry-api-client", () => {
   beforeEach(() => {
-    setRuntime(undefined, undefined);
+    setRuntimeUrl(undefined);
   });
 
   afterEach(() => {
-    setRuntime(undefined, undefined);
+    setRuntimeUrl(undefined);
     global.fetch = originalFetch;
     vi.restoreAllMocks();
   });
 
-  it("resolves config from runtime injection and trims trailing slash", () => {
-    setRuntime("https://fleet-registry-api.example.run.app/", "abc123");
+  it("falls back to the Tailscale HQ default when nothing is configured", () => {
+    setRuntimeUrl(undefined);
     const cfg = resolveRegistryApiConfig();
-    expect(cfg.baseUrl).toBe("https://fleet-registry-api.example.run.app");
-    expect(cfg.token).toBe("abc123");
+    expect(cfg.baseUrl).toBe(DEFAULT_REGISTRY_API_URL);
+    expect(cfg.baseUrl).toBe("http://openclaw-hq:8781");
     expect(cfg.configured).toBe(true);
   });
 
-  it("reports not-configured when url or token is missing", () => {
-    setRuntime("", "");
+  it("resolves config from runtime injection and trims trailing slash", () => {
+    setRuntimeUrl("http://openclaw-hq:8781/");
     const cfg = resolveRegistryApiConfig();
-    expect(cfg.configured).toBe(false);
+    expect(cfg.baseUrl).toBe("http://openclaw-hq:8781");
+    expect(cfg.configured).toBe(true);
   });
 
-  it("throws RegistryApiNotConfiguredError when calling without config", async () => {
-    setRuntime(undefined, undefined);
-    await expect(pairing.list("pending")).rejects.toBeInstanceOf(RegistryApiNotConfiguredError);
-  });
-
-  it("issues GET with bearer token and parses JSON for pairing.list", async () => {
-    setRuntime("https://api.example.com", "tok");
+  it("issues GET WITHOUT an Authorization header for pairing.list", async () => {
+    setRuntimeUrl("http://openclaw-hq:8781");
     const fetchMock = vi.fn(
       async () =>
         new Response(JSON.stringify([{ id: 1, branch_id: "miami" }]), {
@@ -62,13 +59,16 @@ describe("registry-api-client", () => {
     expect(items).toEqual([{ id: 1, branch_id: "miami" }]);
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const [calledUrl, init] = fetchMock.mock.calls[0]!;
-    expect(calledUrl).toBe("https://api.example.com/v1/pairing/requests?status_filter=pending");
+    expect(calledUrl).toBe("http://openclaw-hq:8781/v1/pairing/requests?status_filter=pending");
     expect((init as RequestInit).method).toBe("GET");
-    expect((init as RequestInit).headers).toMatchObject({ Authorization: "Bearer tok" });
+    const headers = (init as RequestInit).headers as Record<string, string>;
+    expect(headers).toMatchObject({ Accept: "application/json" });
+    // VPN is the trust boundary — no bearer token in browser bundle.
+    expect(Object.keys(headers).map((k) => k.toLowerCase())).not.toContain("authorization");
   });
 
-  it("posts JSON body for channels.create", async () => {
-    setRuntime("https://api.example.com", "tok");
+  it("posts JSON body for channels.create without an Authorization header", async () => {
+    setRuntimeUrl("http://openclaw-hq:8781");
     const fetchMock = vi.fn(
       async () =>
         new Response(JSON.stringify({ id: 7, kind: "telegram", name: "Admin Bot" }), {
@@ -94,10 +94,34 @@ describe("registry-api-client", () => {
       config: { chat_id: "-1001" },
       scope: "admin",
     });
+    const headers = (init as RequestInit).headers as Record<string, string>;
+    expect(Object.keys(headers).map((k) => k.toLowerCase())).not.toContain("authorization");
+  });
+
+  it("posts to /v1/notify for notify.broadcast", async () => {
+    setRuntimeUrl("http://openclaw-hq:8781");
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ ok: true, delivered: 3 }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const result = await notify.broadcast({ scope: "admin", text: "hello" });
+    expect(result).toEqual({ ok: true, delivered: 3 });
+    const [calledUrl, init] = fetchMock.mock.calls[0]!;
+    expect(calledUrl).toBe("http://openclaw-hq:8781/v1/notify");
+    expect((init as RequestInit).method).toBe("POST");
+    const body = JSON.parse((init as RequestInit).body as string);
+    expect(body).toEqual({ scope: "admin", text: "hello" });
+    const headers = (init as RequestInit).headers as Record<string, string>;
+    expect(Object.keys(headers).map((k) => k.toLowerCase())).not.toContain("authorization");
   });
 
   it("rejects with RegistryApiError on non-2xx with detail", async () => {
-    setRuntime("https://api.example.com", "tok");
+    setRuntimeUrl("http://openclaw-hq:8781");
     const fetchMock = vi.fn(
       async () =>
         new Response(JSON.stringify({ detail: "nope" }), {

--- a/src/lib/channel-schemas.ts
+++ b/src/lib/channel-schemas.ts
@@ -30,6 +30,13 @@ export const CHANNEL_SCHEMAS: Record<ChannelType, ChannelSchema> = {
         required: true,
         placeholderKey: "console:channels.placeholders.botToken",
       },
+      {
+        key: "chatId",
+        labelKey: "console:channels.fields.chatId",
+        type: "text",
+        required: true,
+        placeholderKey: "console:channels.placeholders.chatId",
+      },
     ],
   },
   discord: {

--- a/src/lib/registry-api-client.ts
+++ b/src/lib/registry-api-client.ts
@@ -1,0 +1,255 @@
+/**
+ * Registry API client for the SitioUno fleet-registry-api Cloud Run service.
+ *
+ * This is a separate, admin-scoped REST channel (NOT routed via the gateway
+ * WebSocket adapter) used by the "Setup GCP" console page to:
+ *   - approve/reject pending pairing requests from new branch nodes (Tailscale)
+ *   - manage GCP Secret Manager-backed notification channels (Telegram first)
+ *
+ * Configuration precedence:
+ *   1. Runtime injection: window.__OPENCLAW_CONFIG__.registryApiUrl/Token
+ *      (mirrors the gateway pattern used in src/App.tsx)
+ *   2. Build-time env: VITE_REGISTRY_API_URL / VITE_REGISTRY_API_TOKEN
+ *
+ * The admin token is treated as a server-side credential. We deliberately:
+ *   - never persist it to localStorage / sessionStorage
+ *   - never log the token value
+ *   - never echo secret values from POST bodies back into UI state once submitted
+ */
+
+// ---------- Types ----------
+
+export type PairingStatus = "pending" | "approved" | "rejected" | "smoke_passed" | "smoke_failed";
+
+export interface PairingRequest {
+  id: number;
+  branch_id: string;
+  hostname: string;
+  tailscale_ip: string;
+  delegate_url: string;
+  coordinator_agent_id: string;
+  allowed_agents: string[];
+  status: PairingStatus;
+  delegation_token_fingerprint: string;
+  metadata?: Record<string, unknown> | null;
+  requested_at: string;
+  decided_at: string | null;
+  decided_by: string | null;
+}
+
+export interface PairingApproveBody {
+  decided_by: string;
+}
+
+export interface PairingRejectBody {
+  decided_by: string;
+  reason: string;
+}
+
+export interface PairingSmokeTestBody {
+  delegation_token: string;
+}
+
+export interface PairingSmokeTestResult {
+  ok: boolean;
+  status?: string;
+  http?: number;
+  detail?: Record<string, unknown> | string | null;
+}
+
+export type ChannelKind = "telegram" | "discord" | "slack" | string;
+export type ChannelScope = "admin" | "branch" | string;
+
+export interface NotificationChannel {
+  id: number;
+  kind: ChannelKind;
+  name: string;
+  config: Record<string, unknown>;
+  secret_ref: string | null;
+  enabled: boolean;
+  scope: ChannelScope;
+  last_test_at: string | null;
+  last_test_result: Record<string, unknown> | null;
+  created_at?: string;
+  updated_at?: string;
+}
+
+export interface CreateChannelBody {
+  kind: ChannelKind;
+  name: string;
+  config: Record<string, unknown>;
+  scope?: ChannelScope;
+}
+
+export interface UpdateChannelBody {
+  config?: Record<string, unknown>;
+  name?: string;
+  enabled?: boolean;
+}
+
+export interface SetSecretBody {
+  secret_value: string;
+}
+
+export interface ChannelTestBody {
+  message?: string;
+}
+
+export interface ChannelTestResult {
+  ok: boolean;
+  http?: number;
+  detail?: Record<string, unknown> | string | null;
+}
+
+// ---------- Config resolution ----------
+
+interface RuntimeConfig {
+  registryApiUrl?: string;
+  registryApiToken?: string;
+}
+
+function readRuntimeConfig(): RuntimeConfig {
+  if (typeof window === "undefined") return {};
+  const injected = (window as unknown as Record<string, unknown>).__OPENCLAW_CONFIG__ as
+    | RuntimeConfig
+    | undefined;
+  return injected ?? {};
+}
+
+export interface RegistryApiResolvedConfig {
+  baseUrl: string;
+  token: string;
+  configured: boolean;
+}
+
+export function resolveRegistryApiConfig(): RegistryApiResolvedConfig {
+  const runtime = readRuntimeConfig();
+  const baseUrl = (
+    runtime.registryApiUrl ||
+    (import.meta.env as unknown as Record<string, string | undefined>).VITE_REGISTRY_API_URL ||
+    ""
+  )
+    .trim()
+    .replace(/\/+$/u, "");
+  const token = (
+    runtime.registryApiToken ||
+    (import.meta.env as unknown as Record<string, string | undefined>).VITE_REGISTRY_API_TOKEN ||
+    ""
+  ).trim();
+  return { baseUrl, token, configured: Boolean(baseUrl && token) };
+}
+
+// ---------- Errors ----------
+
+export class RegistryApiError extends Error {
+  readonly status: number;
+  readonly body: unknown;
+  constructor(status: number, message: string, body?: unknown) {
+    super(message);
+    this.name = "RegistryApiError";
+    this.status = status;
+    this.body = body;
+  }
+}
+
+export class RegistryApiNotConfiguredError extends Error {
+  constructor() {
+    super(
+      "Registry API is not configured. Set VITE_REGISTRY_API_URL + VITE_REGISTRY_API_TOKEN, " +
+        "or inject window.__OPENCLAW_CONFIG__.registryApiUrl/Token at runtime.",
+    );
+    this.name = "RegistryApiNotConfiguredError";
+  }
+}
+
+// ---------- HTTP core ----------
+
+interface RequestOptions {
+  method?: "GET" | "POST" | "PATCH" | "DELETE";
+  body?: unknown;
+  signal?: AbortSignal;
+}
+
+async function request<T>(path: string, opts: RequestOptions = {}): Promise<T> {
+  const { baseUrl, token, configured } = resolveRegistryApiConfig();
+  if (!configured) throw new RegistryApiNotConfiguredError();
+
+  const url = `${baseUrl}${path.startsWith("/") ? path : `/${path}`}`;
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${token}`,
+    Accept: "application/json",
+  };
+  let body: BodyInit | undefined;
+  if (opts.body !== undefined) {
+    headers["Content-Type"] = "application/json";
+    body = JSON.stringify(opts.body);
+  }
+
+  const res = await fetch(url, {
+    method: opts.method ?? "GET",
+    headers,
+    body,
+    signal: opts.signal,
+  });
+
+  let payload: unknown = null;
+  const text = await res.text();
+  if (text) {
+    try {
+      payload = JSON.parse(text);
+    } catch {
+      payload = text;
+    }
+  }
+
+  if (!res.ok) {
+    const message =
+      (payload && typeof payload === "object" && "detail" in payload
+        ? String((payload as { detail?: unknown }).detail)
+        : null) ?? `Registry API ${res.status} on ${opts.method ?? "GET"} ${path}`;
+    throw new RegistryApiError(res.status, message, payload);
+  }
+
+  return payload as T;
+}
+
+// ---------- Resource APIs ----------
+
+export const pairing = {
+  list: (statusFilter: PairingStatus | "all" = "pending") => {
+    const qs = statusFilter === "all" ? "" : `?status_filter=${encodeURIComponent(statusFilter)}`;
+    return request<PairingRequest[]>(`/v1/pairing/requests${qs}`);
+  },
+  get: (id: number) => request<PairingRequest>(`/v1/pairing/requests/${id}`),
+  approve: (id: number, body: PairingApproveBody) =>
+    request<PairingRequest>(`/v1/pairing/requests/${id}/approve`, { method: "POST", body }),
+  reject: (id: number, body: PairingRejectBody) =>
+    request<PairingRequest>(`/v1/pairing/requests/${id}/reject`, { method: "POST", body }),
+  smokeTest: (id: number, body: PairingSmokeTestBody) =>
+    request<PairingSmokeTestResult>(`/v1/pairing/requests/${id}/smoke-test`, {
+      method: "POST",
+      body,
+    }),
+};
+
+export const channels = {
+  list: () => request<NotificationChannel[]>("/v1/channels"),
+  get: (id: number) => request<NotificationChannel>(`/v1/channels/${id}`),
+  create: (body: CreateChannelBody) =>
+    request<NotificationChannel>("/v1/channels", { method: "POST", body }),
+  update: (id: number, body: UpdateChannelBody) =>
+    request<NotificationChannel>(`/v1/channels/${id}`, { method: "PATCH", body }),
+  delete: (id: number) => request<{ ok: boolean }>(`/v1/channels/${id}`, { method: "DELETE" }),
+  setSecret: (id: number, body: SetSecretBody) =>
+    request<NotificationChannel>(`/v1/channels/${id}/secret`, { method: "POST", body }),
+  test: (id: number, body: ChannelTestBody = {}) =>
+    request<ChannelTestResult>(`/v1/channels/${id}/test`, { method: "POST", body }),
+};
+
+export const registryApiClient = {
+  pairing,
+  channels,
+  resolveConfig: resolveRegistryApiConfig,
+};
+
+export default registryApiClient;

--- a/src/lib/registry-api-client.ts
+++ b/src/lib/registry-api-client.ts
@@ -1,20 +1,24 @@
 /**
- * Registry API client for the SitioUno fleet-registry-api Cloud Run service.
+ * Registry API client for the local HQ sidecar.
  *
- * This is a separate, admin-scoped REST channel (NOT routed via the gateway
- * WebSocket adapter) used by the "Setup GCP" console page to:
+ * The "Setup GCP" console page uses this client to:
  *   - approve/reject pending pairing requests from new branch nodes (Tailscale)
  *   - manage GCP Secret Manager-backed notification channels (Telegram first)
+ *   - broadcast notifications via the HQ notify endpoint
  *
- * Configuration precedence:
- *   1. Runtime injection: window.__OPENCLAW_CONFIG__.registryApiUrl/Token
+ * Trust model:
+ *   The HQ sidecar listens on the Tailscale tailnet (default
+ *   `http://openclaw-hq:8781`). The trust boundary is the VPN itself: the
+ *   sidecar validates the source identity server-side via `tailscale whois`.
+ *   This client therefore intentionally has NO bearer token, NO Authorization
+ *   header, and NO admin-credential plumbing. Putting a long-lived token in
+ *   the browser bundle was a regression — the network is the perimeter.
+ *
+ * Configuration precedence (URL only):
+ *   1. Runtime injection: window.__OPENCLAW_CONFIG__.registryApiUrl
  *      (mirrors the gateway pattern used in src/App.tsx)
- *   2. Build-time env: VITE_REGISTRY_API_URL / VITE_REGISTRY_API_TOKEN
- *
- * The admin token is treated as a server-side credential. We deliberately:
- *   - never persist it to localStorage / sessionStorage
- *   - never log the token value
- *   - never echo secret values from POST bodies back into UI state once submitted
+ *   2. Build-time env: VITE_REGISTRY_API_URL
+ *   3. Default: http://openclaw-hq:8781 (Tailscale hostname for HQ)
  */
 
 // ---------- Types ----------
@@ -101,11 +105,27 @@ export interface ChannelTestResult {
   detail?: Record<string, unknown> | string | null;
 }
 
+export interface NotifyBroadcastBody {
+  scope: string;
+  text: string;
+}
+
+export interface NotifyBroadcastResult {
+  ok: boolean;
+  delivered?: number;
+  detail?: Record<string, unknown> | string | null;
+}
+
 // ---------- Config resolution ----------
+
+/**
+ * Default base URL for the HQ sidecar on Tailscale. The sidecar listens on
+ * the tailnet and uses `tailscale whois` for source identity — no bearer.
+ */
+export const DEFAULT_REGISTRY_API_URL = "http://openclaw-hq:8781";
 
 interface RuntimeConfig {
   registryApiUrl?: string;
-  registryApiToken?: string;
 }
 
 function readRuntimeConfig(): RuntimeConfig {
@@ -118,25 +138,17 @@ function readRuntimeConfig(): RuntimeConfig {
 
 export interface RegistryApiResolvedConfig {
   baseUrl: string;
-  token: string;
   configured: boolean;
 }
 
 export function resolveRegistryApiConfig(): RegistryApiResolvedConfig {
   const runtime = readRuntimeConfig();
-  const baseUrl = (
-    runtime.registryApiUrl ||
-    (import.meta.env as unknown as Record<string, string | undefined>).VITE_REGISTRY_API_URL ||
-    ""
-  )
-    .trim()
-    .replace(/\/+$/u, "");
-  const token = (
-    runtime.registryApiToken ||
-    (import.meta.env as unknown as Record<string, string | undefined>).VITE_REGISTRY_API_TOKEN ||
-    ""
+  const fromRuntime = (runtime.registryApiUrl ?? "").trim();
+  const fromEnv = (
+    (import.meta.env as unknown as Record<string, string | undefined>).VITE_REGISTRY_API_URL ?? ""
   ).trim();
-  return { baseUrl, token, configured: Boolean(baseUrl && token) };
+  const baseUrl = (fromRuntime || fromEnv || DEFAULT_REGISTRY_API_URL).replace(/\/+$/u, "");
+  return { baseUrl, configured: Boolean(baseUrl) };
 }
 
 // ---------- Errors ----------
@@ -155,8 +167,9 @@ export class RegistryApiError extends Error {
 export class RegistryApiNotConfiguredError extends Error {
   constructor() {
     super(
-      "Registry API is not configured. Set VITE_REGISTRY_API_URL + VITE_REGISTRY_API_TOKEN, " +
-        "or inject window.__OPENCLAW_CONFIG__.registryApiUrl/Token at runtime.",
+      "Registry API base URL is empty. Set VITE_REGISTRY_API_URL or inject " +
+        "window.__OPENCLAW_CONFIG__.registryApiUrl at runtime (default is " +
+        `${DEFAULT_REGISTRY_API_URL}).`,
     );
     this.name = "RegistryApiNotConfiguredError";
   }
@@ -171,12 +184,12 @@ interface RequestOptions {
 }
 
 async function request<T>(path: string, opts: RequestOptions = {}): Promise<T> {
-  const { baseUrl, token, configured } = resolveRegistryApiConfig();
+  const { baseUrl, configured } = resolveRegistryApiConfig();
   if (!configured) throw new RegistryApiNotConfiguredError();
 
   const url = `${baseUrl}${path.startsWith("/") ? path : `/${path}`}`;
+  // Trust boundary is the VPN — no Authorization header by design.
   const headers: Record<string, string> = {
-    Authorization: `Bearer ${token}`,
     Accept: "application/json",
   };
   let body: BodyInit | undefined;
@@ -246,9 +259,15 @@ export const channels = {
     request<ChannelTestResult>(`/v1/channels/${id}/test`, { method: "POST", body }),
 };
 
+export const notify = {
+  broadcast: (body: NotifyBroadcastBody) =>
+    request<NotifyBroadcastResult>("/v1/notify", { method: "POST", body }),
+};
+
 export const registryApiClient = {
   pairing,
   channels,
+  notify,
   resolveConfig: resolveRegistryApiConfig,
 };
 

--- a/src/store/console-stores/agents-store.ts
+++ b/src/store/console-stores/agents-store.ts
@@ -23,7 +23,7 @@ import {
 } from "@/lib/config-patch-helpers";
 import { clearAgentChannelSessions } from "./agent-session-cleanup";
 
-export type AgentTab = "overview" | "files" | "tools" | "skills" | "channels" | "cronJobs";
+export type AgentTab = "overview" | "files" | "tools" | "skills" | "local_skills" | "channels" | "cronJobs";
 
 export interface SystemModelOption {
   id: string;

--- a/src/store/console-stores/setupgcp-store.ts
+++ b/src/store/console-stores/setupgcp-store.ts
@@ -1,0 +1,219 @@
+import { create } from "zustand";
+import {
+  channels as channelsApi,
+  pairing as pairingApi,
+  resolveRegistryApiConfig,
+  RegistryApiNotConfiguredError,
+  type ChannelTestResult,
+  type CreateChannelBody,
+  type NotificationChannel,
+  type PairingRequest,
+  type PairingStatus,
+  type UpdateChannelBody,
+} from "@/lib/registry-api-client";
+
+function toMessage(err: unknown): string {
+  if (err instanceof RegistryApiNotConfiguredError) return err.message;
+  if (err instanceof Error) return err.message;
+  return String(err);
+}
+
+interface SetupGcpState {
+  // Pairing
+  pairingItems: PairingRequest[];
+  pairingFilter: PairingStatus | "all";
+  pairingLoading: boolean;
+  pairingError: string | null;
+  pairingActionInFlight: Record<number, boolean>;
+
+  // Channels
+  channelItems: NotificationChannel[];
+  channelsLoading: boolean;
+  channelsError: string | null;
+  channelActionInFlight: Record<number, boolean>;
+  lastChannelTest: Record<number, ChannelTestResult | null>;
+
+  // Config readiness
+  configured: boolean;
+  baseUrl: string;
+
+  refreshConfig: () => void;
+
+  fetchPairing: (filter?: PairingStatus | "all") => Promise<void>;
+  setPairingFilter: (filter: PairingStatus | "all") => void;
+  approvePairing: (id: number, decidedBy: string) => Promise<void>;
+  rejectPairing: (id: number, decidedBy: string, reason: string) => Promise<void>;
+
+  fetchChannels: () => Promise<void>;
+  createChannel: (body: CreateChannelBody) => Promise<NotificationChannel | null>;
+  updateChannel: (id: number, body: UpdateChannelBody) => Promise<void>;
+  deleteChannel: (id: number) => Promise<void>;
+  setChannelSecret: (id: number, secret: string) => Promise<void>;
+  testChannel: (id: number, message?: string) => Promise<ChannelTestResult | null>;
+}
+
+const initialConfig = resolveRegistryApiConfig();
+
+export const useSetupGcpStore = create<SetupGcpState>((set, get) => ({
+  pairingItems: [],
+  pairingFilter: "pending",
+  pairingLoading: false,
+  pairingError: null,
+  pairingActionInFlight: {},
+
+  channelItems: [],
+  channelsLoading: false,
+  channelsError: null,
+  channelActionInFlight: {},
+  lastChannelTest: {},
+
+  configured: initialConfig.configured,
+  baseUrl: initialConfig.baseUrl,
+
+  refreshConfig: () => {
+    const cfg = resolveRegistryApiConfig();
+    set({ configured: cfg.configured, baseUrl: cfg.baseUrl });
+  },
+
+  fetchPairing: async (filter) => {
+    const useFilter = filter ?? get().pairingFilter;
+    set({ pairingLoading: true, pairingError: null, pairingFilter: useFilter });
+    try {
+      const items = await pairingApi.list(useFilter);
+      set({ pairingItems: items, pairingLoading: false });
+    } catch (err) {
+      set({ pairingError: toMessage(err), pairingLoading: false });
+    }
+  },
+
+  setPairingFilter: (filter) => {
+    set({ pairingFilter: filter });
+    void get().fetchPairing(filter);
+  },
+
+  approvePairing: async (id, decidedBy) => {
+    set((s) => ({ pairingActionInFlight: { ...s.pairingActionInFlight, [id]: true } }));
+    try {
+      await pairingApi.approve(id, { decided_by: decidedBy });
+      await get().fetchPairing();
+    } catch (err) {
+      set({ pairingError: toMessage(err) });
+    } finally {
+      set((s) => {
+        const next = { ...s.pairingActionInFlight };
+        delete next[id];
+        return { pairingActionInFlight: next };
+      });
+    }
+  },
+
+  rejectPairing: async (id, decidedBy, reason) => {
+    set((s) => ({ pairingActionInFlight: { ...s.pairingActionInFlight, [id]: true } }));
+    try {
+      await pairingApi.reject(id, { decided_by: decidedBy, reason });
+      await get().fetchPairing();
+    } catch (err) {
+      set({ pairingError: toMessage(err) });
+    } finally {
+      set((s) => {
+        const next = { ...s.pairingActionInFlight };
+        delete next[id];
+        return { pairingActionInFlight: next };
+      });
+    }
+  },
+
+  fetchChannels: async () => {
+    set({ channelsLoading: true, channelsError: null });
+    try {
+      const items = await channelsApi.list();
+      set({ channelItems: items, channelsLoading: false });
+    } catch (err) {
+      set({ channelsError: toMessage(err), channelsLoading: false });
+    }
+  },
+
+  createChannel: async (body) => {
+    try {
+      const created = await channelsApi.create(body);
+      await get().fetchChannels();
+      return created;
+    } catch (err) {
+      set({ channelsError: toMessage(err) });
+      return null;
+    }
+  },
+
+  updateChannel: async (id, body) => {
+    set((s) => ({ channelActionInFlight: { ...s.channelActionInFlight, [id]: true } }));
+    try {
+      await channelsApi.update(id, body);
+      await get().fetchChannels();
+    } catch (err) {
+      set({ channelsError: toMessage(err) });
+    } finally {
+      set((s) => {
+        const next = { ...s.channelActionInFlight };
+        delete next[id];
+        return { channelActionInFlight: next };
+      });
+    }
+  },
+
+  deleteChannel: async (id) => {
+    set((s) => ({ channelActionInFlight: { ...s.channelActionInFlight, [id]: true } }));
+    try {
+      await channelsApi.delete(id);
+      await get().fetchChannels();
+    } catch (err) {
+      set({ channelsError: toMessage(err) });
+    } finally {
+      set((s) => {
+        const next = { ...s.channelActionInFlight };
+        delete next[id];
+        return { channelActionInFlight: next };
+      });
+    }
+  },
+
+  setChannelSecret: async (id, secret) => {
+    set((s) => ({ channelActionInFlight: { ...s.channelActionInFlight, [id]: true } }));
+    try {
+      await channelsApi.setSecret(id, { secret_value: secret });
+      await get().fetchChannels();
+    } catch (err) {
+      set({ channelsError: toMessage(err) });
+    } finally {
+      set((s) => {
+        const next = { ...s.channelActionInFlight };
+        delete next[id];
+        return { channelActionInFlight: next };
+      });
+    }
+  },
+
+  testChannel: async (id, message) => {
+    set((s) => ({ channelActionInFlight: { ...s.channelActionInFlight, [id]: true } }));
+    try {
+      const result = await channelsApi.test(id, message ? { message } : {});
+      set((s) => ({ lastChannelTest: { ...s.lastChannelTest, [id]: result } }));
+      // refresh so last_test_at / last_test_result reflect server state
+      await get().fetchChannels();
+      return result;
+    } catch (err) {
+      const msg = toMessage(err);
+      const failure: ChannelTestResult = { ok: false, detail: msg };
+      set((s) => ({
+        lastChannelTest: { ...s.lastChannelTest, [id]: failure },
+        channelsError: msg,
+      }));
+      return failure;
+    } finally {
+      set((s) => {
+        const next = { ...s.channelActionInFlight };
+        delete next[id];
+        return { channelActionInFlight: next };
+      });
+    }
+  },
+}));

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -5,8 +5,14 @@ declare const __APP_VERSION__: string;
 interface ImportMetaEnv {
   readonly VITE_GATEWAY_URL: string;
   readonly VITE_GATEWAY_TOKEN: string;
+  /**
+   * Base URL of the local HQ sidecar that exposes the registry-API surface
+   * (pairing requests + notification channels + notify broadcast).
+   * Defaults to `http://openclaw-hq:8781` on the Tailscale tailnet — the
+   * sidecar uses `tailscale whois` for source identity, so no bearer token
+   * is required (and none should ever be shipped in the browser bundle).
+   */
   readonly VITE_REGISTRY_API_URL?: string;
-  readonly VITE_REGISTRY_API_TOKEN?: string;
 }
 
 interface ImportMeta {

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -5,6 +5,8 @@ declare const __APP_VERSION__: string;
 interface ImportMetaEnv {
   readonly VITE_GATEWAY_URL: string;
   readonly VITE_GATEWAY_TOKEN: string;
+  readonly VITE_REGISTRY_API_URL?: string;
+  readonly VITE_REGISTRY_API_TOKEN?: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## Why

Pieza 6 of the architecture rework. The Setup GCP UI introduced in PR #1 talked to a public Cloud Run endpoint and shipped an admin bearer token in the browser bundle (either via `VITE_REGISTRY_API_TOKEN` or `window.__OPENCLAW_CONFIG__.registryApiToken`). Jean flagged that as exposed surface: any XSS, devtools peek, or accidental log capture leaks a long-lived admin credential.

The new architecture moves all admin traffic inside the Tailscale VPN. A NEW local HQ sidecar listens only on the tailnet (`http://openclaw-hq:8781`) and validates source identity server-side via `tailscale whois`. The trust boundary is the network, not a token in the bundle.

This PR adjusts the registry-API client (and only the client + its tests + env docs) to match. View components are untouched.

## Summary

- **`src/lib/registry-api-client.ts`**:
  - Default base URL `http://openclaw-hq:8781` (Tailscale hostname for HQ). Override via `VITE_REGISTRY_API_URL` or `window.__OPENCLAW_CONFIG__.registryApiUrl`.
  - Remove ALL bearer/token handling: no `Authorization` header, no `VITE_REGISTRY_API_TOKEN`, no `__OPENCLAW_CONFIG__.registryApiToken`, no token in the resolved config.
  - Keep all typed methods (pairing.list/get/approve/reject/smokeTest, channels.list/get/create/update/delete/setSecret/test).
  - Add new method: `notify.broadcast({ scope, text })` → `POST /v1/notify`.
- **`src/vite-env.d.ts`**: drop `VITE_REGISTRY_API_TOKEN`, document the Tailscale default for `VITE_REGISTRY_API_URL`.
- **`.env.example`**: drop the token line, point the URL example at the HQ sidecar, explain the VPN trust model.
- **Tests**:
  - `src/lib/__tests__/registry-api-client.test.ts`: drop bearer-token assertions; add explicit assertions that NO `Authorization` header is sent; add coverage for the Tailscale default and for `notify.broadcast`.
  - `src/components/pages/SetupGcpPage.test.tsx`: with the new default the resolved base URL is always populated, so the "not configured" hint no longer fires from absence-of-config alone. Replaced that assertion with one that the default `openclaw-hq:8781` URL is rendered. Stubbed `fetch` so the page's auto-loaded pairing/channels lists don't hit the network during the test.
- **i18n** (`en` + `zh` `setupGcp.notConfigured.body`): rephrase to mention only the URL knob and the VPN trust boundary.

The `ChannelsPage` GCP banner is unchanged — it already navigates to `/setup-gcp` with copy that doesn't reference the bearer or the external URL.

## Why each test was rewritten

- `registry-api-client.test.ts`: previous tests hard-asserted `Authorization: Bearer tok` and the not-configured error path triggered by absent token. With the bearer removed, those assertions are wrong. They are inverted (assert NO auth header) and the not-configured path is replaced with a default-URL test.
- `SetupGcpPage.test.tsx`: previous test expected the not-configured hint mentioning `VITE_REGISTRY_API_URL`. With the new default URL, `configured` is always true unless someone explicitly clears the URL, so the hint no longer renders by default. Replaced with a test that the default Tailscale URL appears in the page header.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 483/483 passing across 57 files
- [x] `npm run build` — succeeds

References PR #1 (the original Setup GCP introduction) which this PR adjusts.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>