### PR TITLE
feat(ui): show sessions_spawn label instead of agentId

### DIFF
--- a/src/components/chat/SessionSwitcher.tsx
+++ b/src/components/chat/SessionSwitcher.tsx
@@ -14,6 +14,18 @@ function formatSessionName(key: string): string {
   return key.length > 15 ? key.slice(0, 15) + "…" : key;
 }
 
+// Prefer human-readable `label` (passed via sessions_spawn) over the technical
+// session key. The label is preserved by `normalizeSession` in chat-dock-store.
+// Falls back to the formatted key, or a short UUID suffix if the key looks
+// like a raw identifier (no `agent:` prefix).
+function formatSessionDisplay(session: { key: string; label?: string }): string {
+  const label = session.label?.trim();
+  if (label && label !== session.key) {
+    return label.length > 24 ? label.slice(0, 24) + "…" : label;
+  }
+  return formatSessionName(session.key);
+}
+
 function formatRelativeTime(ts: number, t: (key: string, options?: Record<string, unknown>) => string): string {
   const diff = Date.now() - ts;
   const mins = Math.floor(diff / 60_000);
@@ -84,10 +96,13 @@ export function SessionSwitcher() {
     newSession();
   }, [newSession]);
 
-  const displayName = formatSessionName(currentSessionKey);
   const sortedSessions = [...(sessions ?? [])].sort(
     (a, b) => (b.lastActiveAt ?? 0) - (a.lastActiveAt ?? 0),
   );
+  const currentSession = sortedSessions.find((s) => s.key === currentSessionKey);
+  const displayName = currentSession
+    ? formatSessionDisplay(currentSession)
+    : formatSessionName(currentSessionKey);
 
   return (
     <div className="flex items-center gap-1">
@@ -118,7 +133,7 @@ export function SessionSwitcher() {
                   }`}
                 >
                   <div className="min-w-0 flex-1">
-                    <div className="truncate font-medium">{formatSessionName(session.key)}</div>
+                    <div className="truncate font-medium">{formatSessionDisplay(session)}</div>
                     <div className="truncate text-[10px] text-gray-400">
                       {formatRelativeTime(session.lastActiveAt ?? Date.now(), t)}
                       {(session.messageCount ?? 0) > 0 &&

--- a/src/components/pages/ChatPage.tsx
+++ b/src/components/pages/ChatPage.tsx
@@ -50,7 +50,14 @@ function formatSessionTitle(
   sessionKey: string,
   targetAgentId: string | null,
   agents: ReturnType<typeof useOfficeStore.getState>["agents"],
+  sessionLabel?: string | null,
 ): string {
+  // Prefer the human-readable label passed via sessions_spawn (e.g.
+  // "Analyste de portefeuille") over the technical session key / agentId.
+  const label = sessionLabel?.trim();
+  if (label && label !== sessionKey) {
+    return label.length > 32 ? label.slice(0, 32) + "…" : label;
+  }
   const agentId = targetAgentId ?? inferAgentIdFromSessionKey(sessionKey);
   const agentName = resolveAgentDisplayName(agentId, agents);
   if (sessionKey === `agent:${agentId}:main` && agentName) {
@@ -284,7 +291,12 @@ export function ChatPage() {
           <div className="flex items-center justify-between border-b border-gray-100/80 px-6 py-2.5 dark:border-gray-800/80">
             <div className="flex items-center gap-3 overflow-hidden">
               <h2 className="truncate text-[13px] font-semibold text-gray-800 dark:text-gray-200">
-                {formatSessionTitle(currentSessionKey, targetAgentId, agents)}
+                {formatSessionTitle(
+                  currentSessionKey,
+                  targetAgentId,
+                  agents,
+                  sortedSessions.find((s) => s.key === currentSessionKey)?.label,
+                )}
               </h2>
             </div>
             <div className="flex items-center gap-1">

--- a/src/hooks/useSubAgentPoller.ts
+++ b/src/hooks/useSubAgentPoller.ts
@@ -55,10 +55,19 @@ export function toSubAgentInfoList(entries: SessionEntry[]): SubAgentInfo[] {
       // avoid colliding with the parent agent in the store.
       const subUuid = extractSubAgentUuid(sessionKey);
       const effectiveId = subUuid ?? s.agentId ?? sessionKey;
+      // Prefer the explicit human-readable label from sessions_spawn (e.g.
+      // "Analyste de portefeuille"). Treat empty/whitespace-only labels as
+      // absent so the fallback chain still produces something readable.
+      // Fallback order matches existing behavior: explicit label → derived
+      // Sub-<uuid> when sessionKey carries a sub-agent UUID → agentId.
+      const explicitLabel = s.label?.trim();
+      const label =
+        explicitLabel ||
+        (subUuid ? `Sub-${subUuid.slice(0, 6)}` : (s.agentId ?? effectiveId));
       return {
         sessionKey,
         agentId: effectiveId,
-        label: s.label ?? (subUuid ? `Sub-${subUuid.slice(0, 6)}` : (s.agentId ?? effectiveId)),
+        label,
         task: s.task ?? "",
         requesterSessionKey: s.requesterSessionKey!,
         startedAt: s.startedAt ?? s.createdAt ?? Date.now(),

--- a/src/store/office-store.ts
+++ b/src/store/office-store.ts
@@ -861,26 +861,30 @@ export const useOfficeStore = create<OfficeStore>()(
           : null;
 
         if (isSubAgentStart && dataAgentId && parentAgentId && !state.agents.has(dataAgentId)) {
-          // Mock adapter provides explicit sub-agent info — create via addSubAgent post-set
+          // Mock adapter provides explicit sub-agent info — create via addSubAgent post-set.
+          // Use the agentId as the temporary label (real gateway label arrives via
+          // sessionsList poller and overwrites this in `addSubAgent`).
           pendingSubAgentRef.value = {
             parentId: parentAgentId,
             info: {
               sessionKey: event.sessionKey ?? event.runId,
               agentId: dataAgentId,
-              label: `Sub-${dataAgentId.slice(0, 8)}`,
+              label: dataAgentId || `Sub-${dataAgentId.slice(0, 8)}`,
               task: "",
               requesterSessionKey: event.sessionKey ?? "",
               startedAt: event.ts,
             },
           };
         } else if (!state.agents.has(agentId) && isSubAgentSession && parentFromSessionKey) {
-          // Real Gateway sub-agent detected from sessionKey pattern — create via addSubAgent
+          // Real Gateway sub-agent detected from sessionKey pattern — create via addSubAgent.
+          // The sessions_spawn label is not available in the event payload; the
+          // sessions.list poller will overwrite name with the real label shortly.
           pendingSubAgentRef.value = {
             parentId: parentFromSessionKey,
             info: {
               sessionKey: sessionKeyHintEarly,
               agentId,
-              label: `Sub-${agentId.slice(0, 8)}`,
+              label: agentId || `Sub-${agentId.slice(0, 8)}`,
               task: "",
               requesterSessionKey: sessionKeyHintEarly,
               startedAt: event.ts,


### PR DESCRIPTION
## Summary

Make the UI prefer the human-readable `label` field passed via `sessions_spawn` over the technical `agentId` / `sessionKey` UUID. Falls back gracefully if label is missing.

The OpenClaw gateway already accepts and stores a `label` field in `sessions_spawn` (e.g. `"Analyste de portefeuille"`) and exposes it via `sessions.list`. The UI was reading it in `chat-dock-store.normalizeSession` and on the chat page list, but a few prominent UI surfaces still showed only the technical session key. This made multi-agent demos hard to follow because every spawned session appeared as `agent:main:subagent:5533959a-...` instead of its human name.

## Files changed

- `src/components/chat/SessionSwitcher.tsx` — the dropdown items and the active session display name now use `session.label` first via a new `formatSessionDisplay` helper. Previously it only called `formatSessionName(session.key)`.
- `src/components/pages/ChatPage.tsx` — `formatSessionTitle` (used in the chat page header) now accepts a `sessionLabel` arg and prefers it over the agent-name lookup. The single call site passes the active session's label from the sorted list.
- `src/hooks/useSubAgentPoller.ts` — harden `toSubAgentInfoList` against empty/whitespace `label` values (`s.label?.trim() || ...`), keeping the existing fallback chain (`Sub-<uuid>` → `agentId`) for backwards compatibility with the test suite.
- `src/store/office-store.ts` — in `processAgentEvent`'s two pending-sub-agent branches, use the actual `agentId` as the temporary label instead of `Sub-<8-char slice>`. The `sessions.list` poller still overwrites this with the real gateway label as soon as it arrives, but the visible-during-race string is now meaningful.

## Behavior

- When `sessions_spawn` is called with `label: "Analyste de portefeuille"`, both the SessionSwitcher dropdown and the chat page header now display `Analyste de portefeuille…` (truncated at 24/32 chars) instead of `subagent:5533959a-1a5e-…`.
- When no label is provided, the existing behavior is preserved (agent name for `agent:foo:main`, formatted suffix otherwise).

## Test plan

- [x] `npm run typecheck` — passes (no new TS errors)
- [x] `npm test` — 475/475 tests pass, including the existing `useSubAgentPoller` label fallback tests
- [x] `npm run build` — passes (`vite build` produces all expected chunks)
- [ ] Manual: run with a real gateway, call `sessions_spawn` with a label, observe the SessionSwitcher and chat page header show the label
- [ ] Manual: spawn without a label, observe fallback to formatted session key (no regression)

## Notes

- I did not touch `src/i18n/locales/` (concurrent FR translation work in another branch).
- The fallback chain in `useSubAgentPoller` was deliberately kept as `label → Sub-<uuid> → agentId` rather than `label → agentId → Sub-<uuid>` because the parent agent's `agentId` (e.g. `"main"`) shouldn't be displayed as the sub-agent's identity, which an existing test (`subagent-poller.test.ts:124`) explicitly enforces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)